### PR TITLE
import gateway and handler chain code from localstack/localstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,39 @@ app = Request.application(router.dispatch)
 run_simple('localhost', 8080, app, use_reloader=True)
 ```
 
+### Gateway & Handler Chain
+
+A rolo `Gateway` holds a set of request, response, and exception handlers, as well as request finalizers.
+Gateway instances can then be served as WSGI or ASGI applications by using the appropriate serving adapter.
+Here is a simple example of a Gateway with just one handler that returns the URL and method that was invoked.
+
+```python
+from werkzeug import run_simple
+
+from rolo import Response
+from rolo.gateway import Gateway, HandlerChain, RequestContext
+from rolo.gateway.wsgi import WsgiGateway
+
+
+def echo_handler(chain: HandlerChain, context: RequestContext, response: Response):
+    response.status_code = 200
+    response.set_json({"url": context.request.url, "method": context.request.method})
+
+
+gateway = Gateway(request_handlers=[echo_handler])
+
+app = WsgiGateway(gateway)
+run_simple("localhost", 8080, app, use_reloader=True)
+```
+
+Serving this will yield:
+
+```console
+curl http://localhost:8080/hello-world
+{"url": "http://localhost:8080/hello-world", "method": "GET"}
+```
+
+
 ## Develop
 
 ### Quickstart

--- a/rolo/gateway/__init__.py
+++ b/rolo/gateway/__init__.py
@@ -1,0 +1,23 @@
+from .chain import (
+    CompositeExceptionHandler,
+    CompositeFinalizer,
+    CompositeHandler,
+    CompositeResponseHandler,
+    ExceptionHandler,
+    Handler,
+    HandlerChain,
+    RequestContext,
+)
+from .gateway import Gateway
+
+__all__ = [
+    "Gateway",
+    "HandlerChain",
+    "RequestContext",
+    "Handler",
+    "ExceptionHandler",
+    "CompositeHandler",
+    "CompositeExceptionHandler",
+    "CompositeResponseHandler",
+    "CompositeFinalizer",
+]

--- a/rolo/gateway/asgi.py
+++ b/rolo/gateway/asgi.py
@@ -1,0 +1,82 @@
+import asyncio
+import concurrent.futures.thread
+from asyncio import AbstractEventLoop
+from typing import Optional
+
+from rolo.asgi import ASGIAdapter, ASGILifespanListener
+from rolo.websocket.websocket import WebSocketRequest
+
+from .gateway import Gateway
+from .wsgi import WsgiGateway
+
+
+class _ThreadPool(concurrent.futures.thread.ThreadPoolExecutor):
+    """
+    This thread pool executor removes the threads it creates from the global ``_thread_queues`` of
+    ``concurrent.futures.thread``, which joins all created threads at python exit and will block interpreter shutdown if
+    any threads are still running, even if they are daemon threads.
+    """
+
+    def _adjust_thread_count(self) -> None:
+        super()._adjust_thread_count()
+
+        for t in self._threads:
+            if not t.daemon:
+                continue
+            try:
+                del concurrent.futures.thread._threads_queues[t]
+            except KeyError:
+                pass
+
+
+class AsgiGateway:
+    """
+    Exposes a Gateway as an ASGI3 application. Under the hood, it uses a WsgiGateway with a threading async/sync bridge.
+    """
+
+    default_thread_count = 1000
+
+    gateway: Gateway
+
+    def __init__(
+        self,
+        gateway: Gateway,
+        event_loop: Optional[AbstractEventLoop] = None,
+        threads: int = None,
+        lifespan_listener: Optional[ASGILifespanListener] = None,
+        websocket_listener=None,
+    ) -> None:
+        self.gateway = gateway
+
+        self.event_loop = event_loop or asyncio.get_event_loop()
+        self.executor = _ThreadPool(
+            threads or self.default_thread_count, thread_name_prefix="asgi_gw"
+        )
+        self.adapter = ASGIAdapter(
+            WsgiGateway(gateway),
+            event_loop=event_loop,
+            executor=self.executor,
+            lifespan_listener=lifespan_listener,
+            websocket_listener=websocket_listener or WebSocketRequest.listener(gateway.accept),
+        )
+        self._closed = False
+
+    async def __call__(self, scope, receive, send) -> None:
+        """
+        ASGI3 application interface.
+
+        :param scope: the ASGI request scope
+        :param receive: the receive callable
+        :param send: the send callable
+        """
+        if self._closed:
+            raise RuntimeError("Cannot except new request on closed ASGIGateway")
+
+        return await self.adapter(scope, receive, send)
+
+    def close(self):
+        """
+        Close the ASGIGateway by shutting down the underlying executor.
+        """
+        self._closed = True
+        self.executor.shutdown(wait=False, cancel_futures=True)

--- a/rolo/gateway/chain.py
+++ b/rolo/gateway/chain.py
@@ -1,0 +1,376 @@
+"""
+The core concepts of the HandlerChain.
+"""
+from __future__ import annotations
+
+import logging
+import typing as t
+
+from werkzeug.datastructures import Headers
+
+from rolo.request import Request
+from rolo.response import Response
+
+LOG = logging.getLogger(__name__)
+
+
+class RequestContext:
+    """
+    A request context holds the original incoming HTTP Request and arbitrary data. It is passed through the handler
+    chain and allows handlers to communicate.
+    """
+
+    request: Request
+
+    def __setattr__(self, key, value):
+        self.__dict__[key] = value
+
+    def __getattr__(self, item):
+        try:
+            return self.__dict__[item]
+        except KeyError:
+            pass
+        raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{item}")
+
+    def get(self, key: str) -> t.Optional[t.Any]:
+        return self.__dict__.get(key)
+
+
+RC = t.TypeVar("RC", bound=RequestContext)
+
+
+class Handler(t.Protocol[RC]):
+    """The signature of request or response handler in the handler chain. Receives the HandlerChain, the
+    RequestContext, and the Response object to be populated."""
+
+    def __call__(self, chain: "HandlerChain", context: RC, response: Response):
+        ...
+
+
+class ExceptionHandler(t.Protocol[RC]):
+    """The signature of request or response handler in the handler chain. Receives the HandlerChain, the
+    RequestContext, and the Response object to be populated."""
+
+    def __call__(
+        self, chain: "HandlerChain", exception: Exception, context: RC, response: Response
+    ):
+        ...
+
+
+def call_safe(
+    func: t.Callable, args: tuple = None, kwargs: dict = None, exception_message: str = None
+) -> t.Optional[t.Any]:
+    """
+    Call the given function with the given arguments, and if it fails, log the given exception_message.
+    If logging.DEBUG is set for the logger, then we also log the traceback.
+
+    :param func: function to call
+    :param args: arguments to pass
+    :param kwargs: keyword arguments to pass
+    :param exception_message: message to log on exception
+    :return: whatever the func returns
+    """
+    if exception_message is None:
+        exception_message = "error calling function %s" % func.__name__
+    if args is None:
+        args = ()
+    if kwargs is None:
+        kwargs = {}
+
+    try:
+        return func(*args, **kwargs)
+    except Exception as e:
+        if LOG.isEnabledFor(logging.DEBUG):
+            LOG.exception(exception_message)
+        else:
+            LOG.warning("%s: %s", exception_message, e)
+
+
+class HandlerChain(t.Generic[RC]):
+    """
+    Implements a variant of the chain-of-responsibility pattern to process an incoming HTTP request. A handler
+    chain consists of request handlers, response handlers, finalizers, and exception handlers. Each request
+    should have its own HandlerChain instance, since the handler chain holds state for the handling of a
+    request. A chain can be in three states that can be controlled by the handlers.
+
+    * Running - the implicit state where all handlers are executed sequentially
+    * Stopped - a handler has called ``chain.stop()``. This stops the execution of all request handlers, and
+      proceeds immediately to executing the response handlers. Response handlers and finalizers will be run,
+      even if the chain has been stopped.
+    * Terminated - a handler has called ``chain.terminate()`. This stops the execution of all request
+      handlers, and all response handlers, but runs the finalizers at the end.
+
+    If an exception occurs during the execution of request handlers, the chain by default stops the chain,
+    then runs each exception handler, and finally runs the response handlers. Exceptions that happen during
+    the execution of response or exception handlers are logged but do not modify the control flow of the
+    chain.
+    """
+
+    # handlers
+    request_handlers: list[Handler]
+    response_handlers: list[Handler]
+    finalizers: list[Handler]
+    exception_handlers: list[ExceptionHandler]
+
+    # behavior configuration
+    stop_on_error: bool = True
+    """If set to true, the chain will implicitly stop if an error occurs in a request handler."""
+    raise_on_error: bool = False
+    """If set to true, an exception in the request handler will be re-raised by ``handle`` after the exception
+    handlers have been called. """
+
+    # internal state
+    stopped: bool
+    terminated: bool
+    error: t.Optional[Exception]
+    response: t.Optional[Response]
+    context: t.Optional[RequestContext]
+
+    def __init__(
+        self,
+        request_handlers: list[Handler] = None,
+        response_handlers: list[Handler] = None,
+        finalizers: list[Handler] = None,
+        exception_handlers: list[ExceptionHandler] = None,
+    ) -> None:
+        super().__init__()
+        self.request_handlers = request_handlers if request_handlers is not None else []
+        self.response_handlers = response_handlers if response_handlers is not None else []
+        self.exception_handlers = exception_handlers if exception_handlers is not None else []
+        self.finalizers = finalizers if finalizers is not None else []
+
+        self.stopped = False
+        self.terminated = False
+        self.finalized = False
+        self.error = None
+        self.response = None
+        self.context = None
+
+    def handle(self, context: RC, response: Response):
+        """
+        Process the given request and populate the given response according to the handler chain control flow
+        described in the ``HandlerChain`` class doc.
+
+        :param context: the incoming request
+        :param response: the response to be populated
+        """
+        self.context = context
+        self.response = response
+
+        try:
+            for handler in self.request_handlers:
+                try:
+                    handler(self, self.context, response)
+                except Exception as e:
+                    # prepare the continuation behavior, but exception handlers could overwrite it
+                    if self.raise_on_error:
+                        self.error = e
+                    if self.stop_on_error:
+                        self.stopped = True
+
+                    # call exception handlers safely
+                    self._call_exception_handlers(e, response)
+
+                # decide next step
+                if self.error:
+                    raise self.error
+                if self.terminated:
+                    return
+                if self.stopped:
+                    break
+
+            # call response filters
+            self._call_response_handlers(response)
+        finally:
+            if not self.finalized:
+                self._call_finalizers(response)
+
+    def respond(self, status_code: int = 200, payload: t.Any = None, headers: Headers = None):
+        """
+        Convenience method for handlers to stop the chain and set the given status and payload to the
+        current response object.
+
+        :param status_code: the HTTP status code
+        :param payload: the payload of the response
+        :param headers: additional headers
+        """
+        self.response.status_code = status_code
+        if isinstance(payload, (list, dict)):
+            self.response.set_json(payload)
+        elif isinstance(payload, (str, bytes, bytearray)):
+            self.response.data = payload
+        elif payload is None and not self.response.response:
+            self.response.response = []
+        else:
+            self.response.response = payload
+
+        if headers:
+            self.response.headers.update(headers)
+
+        self.stop()
+
+    def stop(self) -> None:
+        """
+        Stop the processing of the request handlers and proceed with response handlers.
+        """
+        self.stopped = True
+
+    def terminate(self) -> None:
+        """
+        Terminate the handler chain, which skips response handlers.
+        """
+        self.terminated = True
+
+    def throw(self, error: Exception) -> None:
+        """
+        Raises the given exception after the current request handler is done. This has no effect in response handlers.
+        :param error: the exception to raise
+        """
+        self.error = error
+
+    def _call_response_handlers(self, response):
+        for handler in self.response_handlers:
+            if self.terminated:
+                return
+
+            try:
+                handler(self, self.context, response)
+            except Exception as e:
+                msg = "exception while running response handler"
+                if LOG.isEnabledFor(logging.DEBUG):
+                    LOG.exception(msg)
+                else:
+                    LOG.warning(msg + ": %s", e)
+
+    def _call_finalizers(self, response):
+        for handler in self.finalizers:
+            try:
+                handler(self, self.context, response)
+            except Exception as e:
+                msg = "exception while running request finalizer"
+                if LOG.isEnabledFor(logging.DEBUG):
+                    LOG.exception(msg)
+                else:
+                    LOG.warning(msg + ": %s", e)
+
+    def _call_exception_handlers(self, e, response):
+        for exception_handler in self.exception_handlers:
+            try:
+                exception_handler(self, e, self.context, response)
+            except Exception as nested:
+                # make sure we run all exception handlers
+                msg = "exception while running exception handler"
+                if LOG.isEnabledFor(logging.DEBUG):
+                    LOG.exception(msg)
+                else:
+                    LOG.warning(msg + ": %s", nested)
+
+
+class CompositeHandler:
+    """
+    A handler that sequentially invokes a list of Handlers, forming a stripped-down version of a handler
+    chain.
+    """
+
+    handlers: list[Handler]
+
+    def __init__(self, return_on_stop=True) -> None:
+        """
+        Creates a new composite handler with an empty handler list.
+
+        TODO: build a proper chain nesting mechanism.
+
+        :param return_on_stop: whether to respect chain.stopped
+        """
+        super().__init__()
+        self.handlers = []
+        self.return_on_stop = return_on_stop
+
+    def append(self, handler: Handler) -> None:
+        """
+        Adds the given handler to the list of handlers.
+
+        :param handler: the handler to add
+        """
+        self.handlers.append(handler)
+
+    def remove(self, handler: Handler) -> None:
+        """
+        Remove the given handler from the list of handlers
+        :param handler: the handler to remove
+        """
+        self.handlers.remove(handler)
+
+    def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
+        for handler in self.handlers:
+            handler(chain, context, response)
+
+            if chain.terminated:
+                return
+            if chain.stopped and self.return_on_stop:
+                return
+
+
+class CompositeExceptionHandler:
+    """
+    A exception handler that sequentially invokes a list of ExceptionHandler instances, forming a
+    stripped-down version of a handler chain for exception handlers.
+    """
+
+    handlers: t.List[ExceptionHandler]
+
+    def __init__(self) -> None:
+        """
+        Creates a new composite exception handler with an empty handler list.
+        """
+        self.handlers = []
+
+    def append(self, handler: ExceptionHandler) -> None:
+        """
+        Adds the given handler to the list of handlers.
+
+        :param handler: the handler to add
+        """
+        self.handlers.append(handler)
+
+    def remove(self, handler: ExceptionHandler) -> None:
+        """
+        Remove the given handler from the list of handlers
+        :param handler: the handler to remove
+        """
+        self.handlers.remove(handler)
+
+    def __call__(
+        self, chain: HandlerChain, exception: Exception, context: RequestContext, response: Response
+    ):
+        for handler in self.handlers:
+            call_safe(
+                handler,
+                args=(chain, exception, context, response),
+                exception_message="exception while running exception handler",
+            )
+
+
+class CompositeResponseHandler(CompositeHandler):
+    """
+    A CompositeHandler that by default does not return on stop, meaning that all handlers in the composite
+    will be executed, even if one of the handlers has called ``chain.stop()``. This mimics how response
+    handlers are executed in the ``HandlerChain``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(return_on_stop=False)
+
+
+class CompositeFinalizer(CompositeResponseHandler):
+    """
+    A CompositeHandler that uses ``call_safe`` to invoke handlers, so every handler is always executed.
+    """
+
+    def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
+        for handler in self.handlers:
+            call_safe(
+                handler,
+                args=(chain, context, response),
+                exception_message="Error while running request finalizer",
+            )

--- a/rolo/gateway/gateway.py
+++ b/rolo/gateway/gateway.py
@@ -1,0 +1,60 @@
+import logging
+
+from ..request import Request
+from ..response import Response
+from ..websocket.websocket import WebSocketRequest
+from .chain import ExceptionHandler, Handler, HandlerChain, RequestContext
+
+LOG = logging.getLogger(__name__)
+
+
+class Gateway:
+    """
+    A gateway creates new HandlerChain instances for each request and processes requests through them.
+    """
+
+    request_handlers: list[Handler]
+    response_handlers: list[Handler]
+    finalizers: list[Handler]
+    exception_handlers: list[ExceptionHandler]
+
+    def __init__(
+        self,
+        request_handlers: list[Handler] = None,
+        response_handlers: list[Handler] = None,
+        finalizers: list[Handler] = None,
+        exception_handlers: list[ExceptionHandler] = None,
+    ) -> None:
+        super().__init__()
+        self.request_handlers = request_handlers if request_handlers is not None else []
+        self.response_handlers = response_handlers if response_handlers is not None else []
+        self.exception_handlers = exception_handlers if exception_handlers is not None else []
+        self.finalizers = finalizers if finalizers is not None else []
+
+    def new_chain(self) -> HandlerChain:
+        return HandlerChain(
+            self.request_handlers,
+            self.response_handlers,
+            self.finalizers,
+            self.exception_handlers,
+        )
+
+    def process(self, request: Request, response: Response):
+        chain = self.new_chain()
+
+        context = RequestContext()
+        context.request = request
+
+        chain.handle(context, response)
+
+    def accept(self, request: WebSocketRequest):
+        response = Response(status=101)
+        self.process(request, response)
+
+        # only send the populated response if the websocket hasn't already done so before
+        if response.status_code != 101:
+            if request.is_upgraded():
+                return
+            if request.is_rejected():
+                return
+            request.reject(response)

--- a/rolo/gateway/handlers.py
+++ b/rolo/gateway/handlers.py
@@ -1,0 +1,84 @@
+"""Several gateway handlers"""
+import typing as t
+
+from werkzeug.datastructures import Headers
+from werkzeug.exceptions import HTTPException, NotFound
+
+from rolo.response import Response
+from rolo.router import Router
+
+from .chain import HandlerChain, RequestContext
+
+
+class RouterHandler:
+    """
+    Adapter to serve a ``Router`` as a ``Handler``.
+    """
+
+    router: Router
+    respond_not_found: bool
+
+    def __init__(self, router: Router, respond_not_found: bool = False) -> None:
+        self.router = router
+        self.respond_not_found = respond_not_found
+
+    def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
+        try:
+            router_response = self.router.dispatch(context.request)
+            response.update_from(router_response)
+            chain.stop()
+        except NotFound:
+            if self.respond_not_found:
+                chain.respond(404, "not found")
+
+
+class EmptyResponseHandler:
+    """
+    Handler that creates a default response if the response in the context is empty.
+    """
+
+    status_code: int
+    body: bytes
+    headers: dict
+
+    def __init__(self, status_code: int = 404, body: bytes = None, headers: Headers = None):
+        self.status_code = status_code
+        self.body = body or b""
+        self.headers = headers or Headers()
+
+    def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
+        if self.is_empty_response(response):
+            self.populate_default_response(response)
+
+    def is_empty_response(self, response: Response):
+        return response.status_code in [0, None] and not response.response
+
+    def populate_default_response(self, response: Response):
+        response.status_code = self.status_code
+        response.data = self.body
+        response.headers.update(self.headers)
+
+
+class WerkzeugExceptionHandler:
+    def __init__(self, output_format: t.Literal["json", "html"] = None) -> None:
+        self.format = output_format or "json"
+
+    def __call__(
+        self, chain: HandlerChain, exception: Exception, context: RequestContext, response: Response
+    ):
+        if not isinstance(exception, HTTPException):
+            return
+
+        headers = Headers(exception.get_headers())  # FIXME
+        headers.pop()
+
+        if self.format == "html":
+            chain.respond(status_code=exception.code, headers=headers, payload=exception.get_body())
+        elif self.format == "json":
+            chain.respond(
+                status_code=exception.code,
+                headers=headers,
+                payload={"code": exception.code, "description": exception.description},
+            )
+        else:
+            raise ValueError(f"unknown rendering format {self.format}")

--- a/rolo/gateway/wsgi.py
+++ b/rolo/gateway/wsgi.py
@@ -1,0 +1,61 @@
+import typing as t
+
+from werkzeug.datastructures import Headers, MultiDict
+from werkzeug.wrappers import Request
+
+from rolo.response import Response
+
+if t.TYPE_CHECKING:
+    from _typeshed.wsgi import StartResponse, WSGIEnvironment
+
+import logging
+
+from .gateway import Gateway
+
+LOG = logging.getLogger(__name__)
+
+
+class WsgiGateway:
+    """
+    Exposes a ``Gateway`` as a WSGI application.
+    """
+
+    gateway: Gateway
+
+    def __init__(self, gateway: Gateway) -> None:
+        super().__init__()
+        self.gateway = gateway
+
+    def __call__(
+        self, environ: "WSGIEnvironment", start_response: "StartResponse"
+    ) -> t.Iterable[bytes]:
+        # create request from environment
+        LOG.debug(
+            "%s %s%s",
+            environ["REQUEST_METHOD"],
+            environ.get("HTTP_HOST"),
+            environ.get("RAW_URI"),
+        )
+        request = Request(environ)
+        if "asgi.headers" in environ:
+            # restores raw headers from ASGI scope, which allows dashes in header keys
+            # see https://github.com/pallets/werkzeug/issues/940
+
+            request.headers = Headers(
+                MultiDict(
+                    [
+                        (k.decode("latin-1"), v.decode("latin-1"))
+                        for (k, v) in environ["asgi.headers"]
+                    ]
+                )
+            )
+        else:
+            # by default, werkzeug requests from environ are immutable
+            request.headers = Headers(request.headers)
+
+        # prepare response
+        response = Response()
+
+        self.gateway.process(request, response)
+
+        return response(environ, start_response)

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+from rolo.gateway import Gateway
+from rolo.testing.pytest import Server
+
+
+@pytest.fixture
+def serve_gateway(request, serve_wsgi_gateway, serve_asgi_gateway):
+    def _serve(gateway: Gateway) -> Server:
+        try:
+            gw_type = request.param
+        except AttributeError:
+            gw_type = "wsgi"
+
+        if gw_type == "asgi":
+            return serve_asgi_gateway(gateway)
+        else:
+            return serve_wsgi_gateway(gateway)
+
+    return _serve

--- a/tests/gateway/test_chain.py
+++ b/tests/gateway/test_chain.py
@@ -1,0 +1,233 @@
+from unittest import mock
+
+from rolo.gateway import CompositeFinalizer, CompositeHandler, HandlerChain, RequestContext
+from rolo.response import Response
+
+
+def test_response_handler_exception():
+    def _raise(*args, **kwargs):
+        raise ValueError("oh noes")
+
+    response1 = mock.MagicMock()
+    response2 = _raise
+    response3 = mock.MagicMock()
+    exception = mock.MagicMock()
+    finalizer = mock.MagicMock()
+
+    chain = HandlerChain(
+        response_handlers=[response1, response2, response3],
+        exception_handlers=[exception],
+        finalizers=[finalizer],
+    )
+    chain.handle(RequestContext(), Response())
+
+    response1.assert_called_once()
+    response3.assert_called_once()  # all response handlers should be called
+    exception.assert_not_called()  # response handlers don't trigger exception handlers
+    finalizer.assert_called_once()
+
+    assert chain.error is None
+
+
+def test_finalizer_handler_exception():
+    def _raise(*args, **kwargs):
+        raise ValueError("oh noes")
+
+    response = mock.MagicMock()
+    exception = mock.MagicMock()
+    finalizer1 = mock.MagicMock()
+    finalizer2 = _raise
+    finalizer3 = mock.MagicMock()
+
+    chain = HandlerChain(
+        response_handlers=[response],
+        exception_handlers=[exception],
+        finalizers=[finalizer1, finalizer2, finalizer3],
+    )
+    chain.handle(RequestContext(), Response())
+
+    response.assert_called_once()
+    exception.assert_not_called()  # response handlers don't trigger exception handlers
+    finalizer1.assert_called_once()
+    finalizer3.assert_called_once()
+
+    assert chain.error is None
+
+
+def test_composite_finalizer_handler_exception():
+    def _raise(*args, **kwargs):
+        raise ValueError("oh noes")
+
+    response = mock.MagicMock()
+    exception = mock.MagicMock()
+    finalizer1 = mock.MagicMock()
+    finalizer2 = _raise
+    finalizer3 = mock.MagicMock()
+
+    finalizer = CompositeFinalizer()
+    finalizer.append(finalizer1)
+    finalizer.append(finalizer2)
+    finalizer.append(finalizer3)
+
+    chain = HandlerChain(
+        response_handlers=[response],
+        exception_handlers=[exception],
+        finalizers=[finalizer],
+    )
+    chain.handle(RequestContext(), Response())
+
+    response.assert_called_once()
+    exception.assert_not_called()  # response handlers don't trigger exception handlers
+    finalizer1.assert_called_once()
+    finalizer3.assert_called_once()
+
+    assert chain.error is None
+
+
+class TestCompositeHandler:
+    def test_composite_handler_stops_handler_chain(self):
+        def inner1(_chain: HandlerChain, request: RequestContext, response: Response):
+            _chain.stop()
+
+        inner2 = mock.MagicMock()
+        outer1 = mock.MagicMock()
+        outer2 = mock.MagicMock()
+        response1 = mock.MagicMock()
+        finalizer = mock.MagicMock()
+
+        chain = HandlerChain()
+
+        composite = CompositeHandler()
+        composite.handlers.append(inner1)
+        composite.handlers.append(inner2)
+
+        chain.request_handlers.append(outer1)
+        chain.request_handlers.append(composite)
+        chain.request_handlers.append(outer2)
+        chain.response_handlers.append(response1)
+        chain.finalizers.append(finalizer)
+
+        chain.handle(RequestContext(), Response())
+        outer1.assert_called_once()
+        outer2.assert_not_called()
+        inner2.assert_not_called()
+        response1.assert_called_once()
+        finalizer.assert_called_once()
+
+    def test_composite_handler_terminates_handler_chain(self):
+        def inner1(_chain: HandlerChain, request: RequestContext, response: Response):
+            _chain.terminate()
+
+        inner2 = mock.MagicMock()
+        outer1 = mock.MagicMock()
+        outer2 = mock.MagicMock()
+        response1 = mock.MagicMock()
+        finalizer = mock.MagicMock()
+
+        chain = HandlerChain()
+
+        composite = CompositeHandler()
+        composite.handlers.append(inner1)
+        composite.handlers.append(inner2)
+
+        chain.request_handlers.append(outer1)
+        chain.request_handlers.append(composite)
+        chain.request_handlers.append(outer2)
+        chain.response_handlers.append(response1)
+        chain.finalizers.append(finalizer)
+
+        chain.handle(RequestContext(), Response())
+        outer1.assert_called_once()
+        outer2.assert_not_called()
+        inner2.assert_not_called()
+        response1.assert_not_called()
+        finalizer.assert_called_once()
+
+    def test_composite_handler_with_not_return_on_stop(self):
+        def inner1(_chain: HandlerChain, request: RequestContext, response: Response):
+            _chain.stop()
+
+        inner2 = mock.MagicMock()
+        outer1 = mock.MagicMock()
+        outer2 = mock.MagicMock()
+        response1 = mock.MagicMock()
+        finalizer = mock.MagicMock()
+
+        chain = HandlerChain()
+
+        composite = CompositeHandler(return_on_stop=False)
+        composite.handlers.append(inner1)
+        composite.handlers.append(inner2)
+
+        chain.request_handlers.append(outer1)
+        chain.request_handlers.append(composite)
+        chain.request_handlers.append(outer2)
+        chain.response_handlers.append(response1)
+        chain.finalizers.append(finalizer)
+
+        chain.handle(RequestContext(), Response())
+        outer1.assert_called_once()
+        outer2.assert_not_called()
+        inner2.assert_called_once()
+        response1.assert_called_once()
+        finalizer.assert_called_once()
+
+    def test_composite_handler_continues_handler_chain(self):
+        inner1 = mock.MagicMock()
+        inner2 = mock.MagicMock()
+        outer1 = mock.MagicMock()
+        outer2 = mock.MagicMock()
+        response1 = mock.MagicMock()
+        finalizer = mock.MagicMock()
+
+        chain = HandlerChain()
+
+        composite = CompositeHandler()
+        composite.handlers.append(inner1)
+        composite.handlers.append(inner2)
+
+        chain.request_handlers.append(outer1)
+        chain.request_handlers.append(composite)
+        chain.request_handlers.append(outer2)
+        chain.response_handlers.append(response1)
+        chain.finalizers.append(finalizer)
+
+        chain.handle(RequestContext(), Response())
+        outer1.assert_called_once()
+        outer2.assert_called_once()
+        inner1.assert_called_once()
+        inner2.assert_called_once()
+        response1.assert_called_once()
+        finalizer.assert_called_once()
+
+    def test_composite_handler_exception_calls_outer_exception_handlers(self):
+        def inner1(_chain: HandlerChain, request: RequestContext, response: Response):
+            raise ValueError()
+
+        inner2 = mock.MagicMock()
+        outer1 = mock.MagicMock()
+        outer2 = mock.MagicMock()
+        exception_handler = mock.MagicMock()
+        response1 = mock.MagicMock()
+        finalizer = mock.MagicMock()
+
+        chain = HandlerChain()
+
+        composite = CompositeHandler()
+        composite.handlers.append(inner1)
+        composite.handlers.append(inner2)
+
+        chain.request_handlers.append(outer1)
+        chain.request_handlers.append(composite)
+        chain.request_handlers.append(outer2)
+        chain.exception_handlers.append(exception_handler)
+        chain.response_handlers.append(response1)
+        chain.finalizers.append(finalizer)
+
+        chain.handle(RequestContext(), Response())
+        outer1.assert_called_once()
+        outer2.assert_not_called()
+        inner2.assert_not_called()
+        exception_handler.assert_called_once()
+        response1.assert_called_once()
+        finalizer.assert_called_once()

--- a/tests/gateway/test_context.py
+++ b/tests/gateway/test_context.py
@@ -1,0 +1,32 @@
+import pytest
+
+from rolo.gateway import RequestContext
+
+
+def test_set_and_access_data():
+    context = RequestContext()
+
+    context.some_data = "foo"
+    assert context.some_data == "foo"
+
+
+def test_access_non_existing_data():
+    context = RequestContext()
+
+    with pytest.raises(AttributeError):
+        assert context.some_data
+
+
+def test_get_non_existing_data():
+    context = RequestContext()
+
+    assert context.get("some_data") is None
+
+
+def test_set_and_get_data():
+    context = RequestContext()
+
+    context.some_data = "foo"
+    assert context.get("some_data") is "foo"
+    context.some_data = "bar"
+    assert context.get("some_data") is "bar"

--- a/tests/gateway/test_handlers.py
+++ b/tests/gateway/test_handlers.py
@@ -1,0 +1,96 @@
+import pytest
+import requests
+from werkzeug import Request
+from werkzeug.exceptions import BadRequest
+
+from rolo import Response, Router
+from rolo.gateway import Gateway, HandlerChain, RequestContext
+from rolo.gateway.handlers import EmptyResponseHandler, RouterHandler, WerkzeugExceptionHandler
+
+
+def _echo_handler(request: Request, args):
+    return Response.for_json(
+        {
+            "path": request.path,
+            "method": request.method,
+            "headers": dict(request.headers),
+        }
+    )
+
+
+@pytest.mark.parametrize("serve_gateway", ["wsgi", "asgi"], indirect=True)
+class TestWerkzeugExceptionHandler:
+    def test_json_output_format(self, serve_gateway):
+        def handler(chain: HandlerChain, context: RequestContext, response: Response):
+            if context.request.method != "GET":
+                raise BadRequest("oh noes")
+
+            chain.respond(payload="ok")
+
+        server = serve_gateway(
+            Gateway(
+                request_handlers=[
+                    handler,
+                ],
+                exception_handlers=[
+                    WerkzeugExceptionHandler(),
+                ],
+            )
+        )
+
+        resp = requests.get(server.url)
+        assert resp.status_code == 200
+        assert resp.text == "ok"
+
+        resp = requests.post(server.url)
+        assert resp.status_code == 400
+        assert resp.json() == {"code": 400, "description": "oh noes"}
+
+
+@pytest.mark.parametrize("serve_gateway", ["wsgi", "asgi"], indirect=True)
+class TestRouterHandler:
+    def test_router_handler_with_respond_not_found(self, serve_gateway):
+        router = Router()
+        router.add("/foo", _echo_handler)
+
+        server = serve_gateway(
+            Gateway(
+                request_handlers=[
+                    RouterHandler(router, True),
+                ],
+            )
+        )
+
+        doc = requests.get(server.url + "/foo", headers={"Foo-Bar": "foobar"}).json()
+        assert doc["path"] == "/foo"
+        assert doc["method"] == "GET"
+        assert doc["headers"]["Foo-Bar"] == "foobar"
+
+        response = requests.get(server.url + "/bar")
+        assert response.status_code == 404
+        assert response.text == "not found"
+
+
+@pytest.mark.parametrize("serve_gateway", ["wsgi", "asgi"], indirect=True)
+class TestEmptyResponseHandler:
+    def test_empty_response_handler(self, serve_gateway):
+        def _handler(chain, context, response):
+            if context.request.method == "GET":
+                chain.respond(202, "ok")
+            else:
+                response.status_code = 0
+
+        server = serve_gateway(
+            Gateway(
+                request_handlers=[_handler],
+                response_handlers=[EmptyResponseHandler(status_code=412, body=b"teapot?")],
+            )
+        )
+
+        response = requests.get(server.url)
+        assert response.text == "ok"
+        assert response.status_code == 202
+
+        response = requests.post(server.url)
+        assert response.text == "teapot?"
+        assert response.status_code == 412

--- a/tests/gateway/test_websocket.py
+++ b/tests/gateway/test_websocket.py
@@ -1,0 +1,27 @@
+import websocket
+
+from rolo import Router, route
+from rolo.gateway import Gateway
+from rolo.gateway.handlers import RouterHandler
+from rolo.websocket.websocket import WebSocketRequest
+
+
+def test_gateway_router_websocket_integration(serve_asgi_gateway):
+    @route("/ws", methods=["WEBSOCKET"])
+    def _handler(request: WebSocketRequest, args):
+        with request.accept() as ws:
+            ws.send("hello")
+            ws.send(ws.receive())
+
+    router = Router()
+    router.add(_handler)
+
+    server = serve_asgi_gateway(Gateway(request_handlers=[RouterHandler(router)]))
+
+    client = websocket.WebSocket()
+    client.connect(server.url.replace("http://", "ws://") + "/ws")
+
+    assert client.recv() == "hello"
+    client.send("foobar")
+    assert client.recv() == "foobar"
+    client.close()


### PR DESCRIPTION
This PR moves the `Gateway` and `HandlerChain` concepts from localstack into rolo. There are some slight adaptations to the testing framework, as well as the `RequestContext`, which is now generalized and can hold arbitrary data. Other than that it's pretty much just the framework developed on top of https://github.com/localstack/localstack/pull/5243