### PR TITLE
make Router.add thread safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ $(VENV_ACTIVATE): pyproject.toml
 install: venv
 
 clean:
+	rm -rf .venv
 	rm -rf build/
 	rm -rf .eggs/
 	rm -rf *.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["readme"]
 
 [project.optional-dependencies]
 dev = [
-    "black>=22.1",
+    "black==23.10.0",
     "pytest>=7.0",
     "hypercorn",
     "pytest_httpserver",


### PR DESCRIPTION
## Motivation

We've seen concurrency errors in LocalStack's Lambda provider that dynamically adds rules for each lambda.
```
2024-01-17T00:08:33.095 ERROR --- [ asgi_gw_151] l.aws.handlers.logging     : exception during call chain
Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/chain.py", line 99, in handle
    handler(self, self.context, response)
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/aws/handlers/routes.py", line 27, in __call__
    router_response = self.router.dispatch(context.request)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/localstack/http/router.py", line 351, in dispatch
    handler, args = matcher.match(get_raw_path(request), method=request.method)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/werkzeug/routing/map.py", line 582, in match
    self.map.update()
  File "/opt/code/localstack/.venv/lib/python3.11/site-packages/werkzeug/routing/map.py", line 365, in update
    for rules in self._rules_by_endpoint.values():
RuntimeError: dictionary changed size during iteration
```

Werkzeug url maps are not thread safe, and the only two options to fix this is either introducing locks for `Router.dispatch`, or create a new map every time `Router.add` is called. With this change, `add` is now about 10X slower, (creating a router with 50 rules takes ~50ms now, compared to ~5ms).

## Changes

* `Router.add` is now thread safe by always creating a new `Map` instance, but therefore significantly slower