### PR TITLE
refactor websockets to allow different implementations

### DIFF
--- a/rolo/asgi.py
+++ b/rolo/asgi.py
@@ -9,6 +9,19 @@ from concurrent.futures import Executor
 from io import BufferedReader, RawIOBase
 from urllib.parse import quote, unquote, urlparse
 
+from werkzeug.datastructures import Headers
+
+from rolo.websocket.adapter import (
+    BytesMessage,
+    CreateConnection,
+    Message,
+    TextMessage,
+    WebSocketAdapter,
+    WebSocketEnvironment,
+    WebSocketListener,
+)
+from rolo.websocket.errors import WebSocketDisconnectedError, WebSocketProtocolError
+
 if t.TYPE_CHECKING:
     from _typeshed import WSGIApplication, WSGIEnvironment
     from hypercorn.typing import (
@@ -42,9 +55,6 @@ if t.TYPE_CHECKING:
     ]
 
 LOG = logging.getLogger(__name__)
-
-WebSocketEnvironment: t.TypeAlias = t.Dict[str, t.Any]
-"""Special WSGIEnvironment that has an `asgi.websocket` key that stores a `Websocket` instance."""
 
 
 def populate_wsgi_environment(
@@ -327,12 +337,9 @@ class ASGILifespanListener:
         pass
 
 
-class ASGIWebSocket:
+class ASGIWebSocketAdapter(WebSocketAdapter):
     """
-    A wrapper around an ASGI ``WebsocketScope`` and relevant IO objects that can be used to interact with the websocket
-    in synchronous code.
-
-    For send and receive event formats, see https://asgi.readthedocs.io/en/latest/specs/www.html#websocket.
+    Adapter code to serve a ``rolo.websocket.WebSocketRequest`` through ASGI.
     """
 
     _scope: "WebsocketScope"
@@ -351,13 +358,13 @@ class ASGIWebSocket:
         self._send = send
         self._loop = loop
 
-    async def send_async(self, event: "_WebsocketResponse"):
+    async def asgi_send_async(self, event: "_WebsocketResponse"):
         await self._send(event)
 
-    async def receive_async(self) -> "_WebsocketRequest":
+    async def asgi_receive_async(self) -> "_WebsocketRequest":
         return await self._receive()
 
-    def send(self, event: "_WebsocketResponse", timeout: float = None) -> None:
+    def asgi_send(self, event: "_WebsocketResponse", timeout: float = None) -> None:
         """
         Sends an event to the Websocket. Events can be:
 
@@ -368,11 +375,11 @@ class ASGIWebSocket:
         :param event: The event to send
         :param timeout: The number of seconds to wait for the result of the async call
         """
-        return asyncio.run_coroutine_threadsafe(self.send_async(event), self._loop).result(
+        return asyncio.run_coroutine_threadsafe(self.asgi_send_async(event), self._loop).result(
             timeout=timeout
         )
 
-    def receive(self, timeout: float = None) -> "_WebsocketRequest":
+    def asgi_receive(self, timeout: float = None) -> "_WebsocketRequest":
         """
         Listens on the websocket and returns the next event. Events can be:
 
@@ -383,73 +390,116 @@ class ASGIWebSocket:
         :param timeout: The number of seconds to wait for the event
         :return: The received event
         """
-        return asyncio.run_coroutine_threadsafe(self.receive_async(), self._loop).result(timeout)
+        return asyncio.run_coroutine_threadsafe(self.asgi_receive_async(), self._loop).result(
+            timeout
+        )
+
+    def receive(self, timeout: float = None) -> CreateConnection | Message:
+        event = self.asgi_receive(timeout)
+
+        # user-facing events
+        if event["type"] == "websocket.connect":
+            return CreateConnection()
+
+        if event["type"] == "websocket.receive":
+            event: "WebsocketReceiveEvent"
+            text = event.get("text")
+            if text is not None:
+                return TextMessage(text)
+
+            buf: bytes = event.get("bytes")
+            if buf is not None:
+                return BytesMessage(buf)
+
+            raise WebSocketProtocolError(
+                "Both bytes and text are None in the websocket.receive event."
+            )
+
+        # internal events
+        if event["type"] == "websocket.disconnect":
+            event: "WebsocketDisconnectEvent"
+            raise WebSocketDisconnectedError(event["code"])
+
+    def send(self, event: Message, timeout: float = None):
+        if isinstance(event, TextMessage):
+            asgi_event = {
+                "type": "websocket.send",
+                "text": event.data,
+                "bytes": None,
+            }
+        elif isinstance(event, BytesMessage):
+            asgi_event = {
+                "type": "websocket.send",
+                "text": None,
+                "bytes": event.data,
+            }
+        else:
+            raise TypeError(f"Unknown message type {event.__class__.__name__}")
+
+        self.asgi_send(asgi_event, timeout=timeout)
 
     def respond(
-        self, status: int, headers: list[tuple[str, str]] = None, body: t.Iterable[bytes] = None
+        self,
+        status_code: int,
+        headers: Headers = None,
+        body: t.Iterable[bytes] = None,
+        timeout: float = None,
     ):
-        self.send(
+        self.asgi_send(
             {
                 "type": "websocket.http.response.start",
-                "status": status,
-                "headers": [(h[0].encode("latin1"), h[1].encode("latin1")) for h in headers],
-            }
+                "status": status_code,
+                "headers": self._to_asgi_headers(headers) if headers else [],
+            },
+            timeout=timeout,
         )
         if body:
             for chunk in body:
-                self.send(
+                self.asgi_send(
                     {
                         "type": "websocket.http.response.body",
                         "body": chunk,
                         "more_body": True,
-                    }
+                    },
+                    timeout=timeout,
                 )
-        self.send(
+        self.asgi_send(
             {
                 "type": "websocket.http.response.body",
                 "body": b"",
                 "more_body": False,
-            }
+            },
+            timeout=timeout,
         )
 
+    def accept(
+        self,
+        subprotocol: str = None,
+        extensions: list[str] = None,
+        extra_headers: Headers = None,
+        timeout: float = None,
+    ):
+        self.asgi_send(
+            {
+                "type": "websocket.accept",
+                "subprotocol": subprotocol,
+                "headers": self._to_asgi_headers(extra_headers) if extra_headers else [],
+            },
+            timeout=timeout,
+        )
 
-class WebSocketListener(t.Protocol):
-    """
-    Similar protocol to a WSGIApplication, only it expects a Websocket instead of a WSGIEnvironment.
-    """
+    def close(self, code: int = 1001, reason: str = None, timeout: float = None):
+        self.asgi_send(
+            {
+                "type": "websocket.close",
+                "code": code,
+                "reason": reason,
+            },
+            timeout=timeout,
+        )
 
-    def __call__(self, environ: WebSocketEnvironment):
-        """
-        Called when a new Websocket connection is established. To initiate the connection, you need to perform the
-        connect handshake yourself. First, receive the ``websocket.connect`` event, and then send the
-        ``websocket.accept`` event. Here's a minimal example::
-
-            def accept(self, environ: WebsocketEnvironment):
-                websocket = environ['asgi.websocket']
-                event = websocket.receive()
-                if event['type'] == "websocket.connect":
-                    websocket.send({
-                        "type": "websocket.accept",
-                        "subprotocol": None,
-                        "headers": [],
-                    })
-                else:
-                    websocket.send({
-                        "type": "websocket.close",
-                        "code": 1002, # protocol error
-                        "reason": None,
-                    })
-                    return
-
-                while True:
-                    event = websocket.receive()
-                    if event["type"] == "websocket.disconnect":
-                        return
-                    print(event)
-
-        :param environ: The new Websocket environment
-        """
-        raise NotImplementedError
+    def _to_asgi_headers(self, headers: Headers) -> t.List[t.Tuple[bytes, bytes]]:
+        return [(h[0].encode("latin1"), h[1].encode("latin1")) for h in headers.to_wsgi_list()]
 
 
 class ASGIAdapter:
@@ -578,7 +628,8 @@ class ASGIAdapter:
         environ: WebSocketEnvironment = {}
         populate_wsgi_environment(environ, scope)
         environ["REQUEST_METHOD"] = "WEBSOCKET"
-        environ["asgi.websocket"] = ASGIWebSocket(scope, receive, send, self.event_loop)
+        environ["rolo.websocket"] = ASGIWebSocketAdapter(scope, receive, send, self.event_loop)
+        environ["asgi.websocket"] = environ["rolo.websocket"]
         return environ
 
     async def handle_websocket(

--- a/rolo/gateway/asgi.py
+++ b/rolo/gateway/asgi.py
@@ -4,7 +4,7 @@ from asyncio import AbstractEventLoop
 from typing import Optional
 
 from rolo.asgi import ASGIAdapter, ASGILifespanListener
-from rolo.websocket.websocket import WebSocketRequest
+from rolo.websocket.request import WebSocketRequest
 
 from .gateway import Gateway
 from .wsgi import WsgiGateway

--- a/rolo/gateway/gateway.py
+++ b/rolo/gateway/gateway.py
@@ -3,7 +3,7 @@ import typing as t
 
 from ..request import Request
 from ..response import Response
-from ..websocket.websocket import WebSocketRequest
+from ..websocket.request import WebSocketRequest
 from .chain import ExceptionHandler, Handler, HandlerChain, RequestContext
 
 LOG = logging.getLogger(__name__)

--- a/rolo/testing/pytest.py
+++ b/rolo/testing/pytest.py
@@ -12,11 +12,12 @@ from werkzeug import Request as WerkzeugRequest
 from werkzeug import serving
 
 from rolo import Router
-from rolo.asgi import ASGIAdapter, ASGILifespanListener, WebSocketListener
+from rolo.asgi import ASGIAdapter, ASGILifespanListener
 from rolo.dispatcher import handler_dispatcher
 from rolo.gateway import Gateway
 from rolo.gateway.asgi import AsgiGateway
 from rolo.gateway.wsgi import WsgiGateway
+from rolo.websocket.adapter import WebSocketListener
 
 if typing.TYPE_CHECKING:
     from hypercorn.typing import ASGIFramework

--- a/rolo/websocket/__init__.py
+++ b/rolo/websocket/__init__.py
@@ -1,0 +1,13 @@
+from .adapter import WebSocketEnvironment, WebSocketListener
+from .errors import WebSocketDisconnectedError, WebSocketError, WebSocketProtocolError
+from .request import WebSocket, WebSocketRequest
+
+__all__ = [
+    "WebSocket",
+    "WebSocketDisconnectedError",
+    "WebSocketEnvironment",
+    "WebSocketError",
+    "WebSocketListener",
+    "WebSocketProtocolError",
+    "WebSocketRequest",
+]

--- a/rolo/websocket/adapter.py
+++ b/rolo/websocket/adapter.py
@@ -1,0 +1,125 @@
+"""Adapter API between high-level rolo.websocket.request and an underlying IO framework like ASGI or
+twisted."""
+import dataclasses
+import typing as t
+
+from werkzeug.datastructures import Headers
+
+WebSocketEnvironment: t.TypeAlias = t.Dict[str, t.Any]
+"""Special WSGIEnvironment that has a ``rolo.websocket`` key that stores a `Websocket` instance."""
+
+
+class Event:
+    pass
+
+
+@dataclasses.dataclass
+class Message(Event):
+    data: bytes | str
+
+
+@dataclasses.dataclass
+class TextMessage(Message):
+    data: str
+
+
+@dataclasses.dataclass
+class BytesMessage(Message):
+    data: bytes
+
+
+@dataclasses.dataclass
+class CreateConnection(Event):
+    pass
+
+
+@dataclasses.dataclass
+class AcceptConnection(Event):
+    subprotocol: t.Optional[str] = None
+    extensions: list[str] = dataclasses.field(default_factory=list)
+    extra_headers: list[tuple[bytes, bytes]] = dataclasses.field(default_factory=list)
+
+
+class WebSocketAdapter:
+    """
+    Adapter to plug the high-level interfaces ``WebSocket`` and ``WebSocketRequest`` into an IO framework.
+    It doesn't cover the full websocket protocol API (for instance there are no Ping/Pong events),
+    under the assumption that the lower-level IO framework will abstract them away.
+    """
+
+    def receive(
+        self,
+        timeout: float = None,
+    ) -> CreateConnection | Message:
+        raise NotImplementedError
+
+    def send(
+        self,
+        event: Message,
+        timeout: float = None,
+    ):
+        raise NotImplementedError
+
+    def respond(
+        self,
+        status_code: int,
+        headers: Headers = None,
+        body: t.Iterable[bytes] = None,
+        timeout: float = None,
+    ):
+        raise NotImplementedError
+
+    def accept(
+        self,
+        subprotocol: str = None,
+        extensions: list[str] = None,
+        extra_headers: Headers = None,
+        timeout: float = None,
+    ):
+        raise NotImplementedError
+
+    def close(self, code: int = 1001, reason: str = None, timeout: float = None):
+        """
+        If the underlying websocket connection has already been closed, this call is ignore, so it's safe
+        to always call.
+        """
+        raise NotImplementedError
+
+
+class WebSocketListener(t.Protocol):
+    """
+    Similar protocol to a WSGIApplication, only it expects a Websocket instead of a WSGIEnvironment.
+    """
+
+    def __call__(self, environ: WebSocketEnvironment):
+        """
+        Called when a new Websocket connection is established. To initiate the connection, you need to perform the
+        connect handshake yourself. First, receive the ``websocket.connect`` event, and then send the
+        ``websocket.accept`` event. Here's a minimal example::
+
+            def accept(self, environ: WebsocketEnvironment):
+                websocket = environ['rolo.websocket']
+                event = websocket.receive()
+                if event['type'] == "websocket.connect":
+                    websocket.send({
+                        "type": "websocket.accept",
+                        "subprotocol": None,
+                        "headers": [],
+                    })
+                else:
+                    websocket.send({
+                        "type": "websocket.close",
+                        "code": 1002, # protocol error
+                        "reason": None,
+                    })
+                    return
+
+                while True:
+                    event = websocket.receive()
+                    if event["type"] == "websocket.disconnect":
+                        return
+                    print(event)
+
+        :param environ: The new Websocket environment
+        """
+        raise NotImplementedError

--- a/rolo/websocket/errors.py
+++ b/rolo/websocket/errors.py
@@ -1,0 +1,21 @@
+class WebSocketError(IOError):
+    """Base class for websocket errors"""
+
+    pass
+
+
+class WebSocketDisconnectedError(WebSocketError):
+    """Raised when the client has disconnected while the server is still trying to receive data."""
+
+    default_code = 1005
+    """https://asgi.readthedocs.io/en/latest/specs/www.html#disconnect-receive-event-ws"""
+
+    def __init__(self, code: int = None):
+        self.code = code if code is not None else self.default_code
+        super().__init__(f"Websocket disconnected code={self.code}")
+
+
+class WebSocketProtocolError(WebSocketError):
+    """Raised if there is a problem in the interaction between app and the websocket server."""
+
+    pass

--- a/rolo/websocket/request.py
+++ b/rolo/websocket/request.py
@@ -230,7 +230,7 @@ class WebSocketRequest(_SansIORequest):
     def listener(cls, fn: t.Callable[["WebSocketRequest"], None]) -> WebSocketListener:
         """
         Convenience function inspired by ``werkzeug.Request.application`` that transforms a function into a
-        ``WebsocketListener`` for the use in an ``ASGIAdapter``. Example::
+        ``WebsocketListener`` for the use in server code that support ``WebsocketListeners``. Example::
 
             @WebsocketRequest.listener
             def app(request: WebSocketRequest):

--- a/rolo/websocket/request.py
+++ b/rolo/websocket/request.py
@@ -111,7 +111,7 @@ class WebSocketRequest(_SansIORequest):
     def __init__(self, environ: WebSocketEnvironment):
         """
         Creates a new request from the given WebSocketEnvironment. This is like a sans-IO WSGI Environment,
-        with an additional field ``asgi.websocket`` that contains an ``ASGIWebSocket`` interface.
+        with an additional field ``rolo.websocket`` that contains a ``WebSocketAdapter`` interface.
 
         :param environ: the WebSocketEnvironment
         """
@@ -191,8 +191,8 @@ class WebSocketRequest(_SansIORequest):
                     data = websocket.receive()
                     # ...
 
-        The handshake using the ASGI websocket works as followsL receive the ``websocket.connect`` event
-        from the websocket and then send the ``websocket.accept`` event. If the handshake failed because
+        The handshake using the WebSocketAdapter works as follows: receive the ``CreateConnection`` event
+        from the websocket and then call the ``socket.accept(...)``. If the handshake failed because
         the websocket sent an unexpected exception, the connection is closed and the method raises an error.
 
         :param subprotocol: The subprotocol the server wishes to accept. Optional
@@ -212,8 +212,9 @@ class WebSocketRequest(_SansIORequest):
             self._upgraded = True
             return WebSocket(self, self.socket)
         else:
-            self.socket.close(1003, f"Unexpected event {event.__class__.__name__}")
-            raise WebSocketProtocolError(f"Unexpected event {event}")
+            reason = f"Unexpected event {event.__class__.__name__}"
+            self.socket.close(1003, reason)
+            raise WebSocketProtocolError(reason)
 
     def close(self):
         """

--- a/rolo/websocket/websocket.py
+++ b/rolo/websocket/websocket.py
@@ -1,0 +1,14 @@
+"""TODO: remove with release (just keeping this so localstack doesn't blow up)"""
+from .adapter import WebSocketEnvironment, WebSocketListener
+from .errors import WebSocketDisconnectedError, WebSocketError, WebSocketProtocolError
+from .request import WebSocket, WebSocketRequest
+
+__all__ = [
+    "WebSocket",
+    "WebSocketDisconnectedError",
+    "WebSocketEnvironment",
+    "WebSocketError",
+    "WebSocketListener",
+    "WebSocketProtocolError",
+    "WebSocketRequest",
+]

--- a/tests/gateway/test_websocket.py
+++ b/tests/gateway/test_websocket.py
@@ -3,7 +3,7 @@ import websocket
 from rolo import Router, route
 from rolo.gateway import Gateway
 from rolo.gateway.handlers import RouterHandler
-from rolo.websocket.websocket import WebSocketRequest
+from rolo.websocket.request import WebSocketRequest
 
 
 def test_gateway_router_websocket_integration(serve_asgi_gateway):

--- a/tests/websocket/test_websockets.py
+++ b/tests/websocket/test_websockets.py
@@ -7,7 +7,7 @@ import websocket
 from werkzeug.datastructures import Headers
 
 from rolo import Router
-from rolo.websocket.websocket import (
+from rolo.websocket.request import (
     WebSocketDisconnectedError,
     WebSocketProtocolError,
     WebSocketRequest,


### PR DESCRIPTION
## Motivation

In https://github.com/localstack/localstack/pull/9834 we added twisted to serve a `Gateway` instance, with the limitation of not having websocket support.
While implementing websocket support for twisted, I noticed that introducing an adapter layer between `WebSocketRequest`/`WebSocket` and the underlying IO framework would be useful. Previously the upper layer was using ASGI events directly. Now it interacts with an intermediary `WebSocketAdapter` interface, allowing maximal code re-use, and isolating IO implementation to the adapter.

## Changes

* introduced `"rolo.websocket"` and `"rolo.websocket"` environment fields 
* preparing migration of `asgi.headers` -> `rolo.headers`
* preparing migration of `asgi.websocket` -> `rolo.websocket`
* the `"rolo.websocket"` field is now expected to be a `WebSocketAdapter` instance
* freed `WebSocketRequest` and `WebSocket` of any ASGI assumptions
* most changes should be backwards compatible, import references to `rolo.websocket.websocket` were kept, but will be removed soon
