### PR TITLE
allow lists as return types for handler dispatchers

### DIFF
--- a/rolo/dispatcher.py
+++ b/rolo/dispatcher.py
@@ -12,6 +12,7 @@ ResultValue = Union[
     str,
     bytes,
     Dict[str, Any],  # a JSON dict
+    list[Any],
 ]
 
 
@@ -23,7 +24,7 @@ def _populate_response(
 
     elif isinstance(result, (str, bytes, bytearray)):
         response.data = result
-    elif isinstance(result, dict):
+    elif isinstance(result, (dict, list)):
         response.data = json.dumps(result, cls=json_encoder)
         response.mimetype = "application/json"
     else:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -48,6 +48,21 @@ class TestHandlerDispatcher:
         router.add("/foo/<arg1>", handler)
         assert router.dispatch(Request("GET", "/foo/a")).json == {"arg1": "a", "hello": "there"}
 
+    def test_handler_dispatcher_with_list_return(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request, arg1) -> Dict[str, Any]:
+            return [{"arg1": arg1, "hello": "there"}, 1, 2, "3", [4, 5]]
+
+        router.add("/foo/<arg1>", handler)
+        assert router.dispatch(Request("GET", "/foo/a")).json == [
+            {"arg1": "a", "hello": "there"},
+            1,
+            2,
+            "3",
+            [4, 5],
+        ]
+
     def test_handler_dispatcher_with_text_return(self):
         router = Router(dispatcher=handler_dispatcher())
 


### PR DESCRIPTION
## Motivation


Routers with handler dispatchers already allowed dictionaries as return types which automatically get converted into JSON:

```python
@route("/foo/<arg1>")
def handler(request: Request, arg1) -> Dict[str, Any]:
    return {"arg1": arg1, "hello": "there"}
```

But not lists. With this PR you can also:

```python
@route("/foo/<arg1>")
def handler(request: Request, arg1) -> Dict[str, Any]:
    return [{"arg1": arg1, "hello": "there"}, 1, 2, 3]
```

## Changes

* Routes that use the `handler_dispatcher()` can now convert lists into json responses
