### PR TITLE
add method to create response from a static resource

### DIFF
--- a/rolo/router.py
+++ b/rolo/router.py
@@ -24,6 +24,9 @@ from werkzeug.routing import BaseConverter, Map, Rule, RuleFactory
 
 from .request import get_raw_path
 
+if t.TYPE_CHECKING:
+    from _typeshed.wsgi import WSGIApplication
+
 HTTP_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE")
 
 E = TypeVar("E")
@@ -402,6 +405,23 @@ class Router(Generic[E]):
             return fn
 
         return wrapper
+
+    def wsgi(self) -> "WSGIApplication":
+        """
+        Returns this router as a WSGI compatible interface. This can be used to conveniently serve a Router instance
+        through a WSGI server, for instance werkzeug's dev server::
+
+            from werkzeug.serving import run_simple
+
+            from rolo import Router
+            from rolo.dispatcher import handler_dispatcher
+
+            router = Router(dispatcher=handler_dispatcher())
+            run_simple("localhost", 5000, router.wsgi())
+
+        :return: a WSGI callable that invokes this router
+        """
+        return Request.application(self.dispatch)
 
 
 class RuleAdapter(RuleFactory):

--- a/tests/static/index.html
+++ b/tests/static/index.html
@@ -1,0 +1,3 @@
+<html lang="en">
+<body>hello</body>
+</html>

--- a/tests/static/test.txt
+++ b/tests/static/test.txt
@@ -1,0 +1,1 @@
+hello world

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,84 @@
+import io
+
+import pytest
+from werkzeug.exceptions import NotFound
+
+from rolo import Response
+from tests import static
+
+
+def test_for_resource_html():
+    response = Response.for_resource(static, "index.html")
+    assert response.content_type == "text/html; charset=utf-8"
+    assert response.get_data() == b'<html lang="en">\n<body>hello</body>\n</html>\n'
+    assert response.status == "200 OK"
+
+
+def test_for_resource_txt():
+    response = Response.for_resource(static, "test.txt")
+    assert response.content_type == "text/plain; charset=utf-8"
+    assert response.get_data() == b"hello world\n"
+    assert response.status == "200 OK"
+
+
+def test_for_resource_with_custom_response_status_and_headers():
+    response = Response.for_resource(static, "test.txt", status=201, headers={"X-Foo": "Bar"})
+    assert response.content_type == "text/plain; charset=utf-8"
+    assert response.get_data() == b"hello world\n"
+    assert response.status == "201 CREATED"
+    assert response.headers.get("X-Foo") == "Bar"
+
+
+def test_for_resource_not_found():
+    with pytest.raises(NotFound):
+        Response.for_resource(static, "doesntexist.txt")
+
+
+def test_for_json():
+    response = Response.for_json(
+        {"foo": "bar", "420": 69, "isTrue": True},
+    )
+    assert response.content_type == "application/json"
+    assert response.get_data() == b'{"foo": "bar", "420": 69, "isTrue": true}'
+    assert response.status == "200 OK"
+
+
+def test_for_json_with_custom_response_status_and_headers():
+    response = Response.for_json(
+        {"foo": "bar", "420": 69, "isTrue": True},
+        status=201,
+        headers={"X-Foo": "Bar"},
+    )
+    assert response.content_type == "application/json"
+    assert response.get_data() == b'{"foo": "bar", "420": 69, "isTrue": true}'
+    assert response.status == "201 CREATED"
+    assert response.headers.get("X-Foo") == "Bar"
+
+
+@pytest.mark.parametrize(
+    argnames="data",
+    argvalues=[
+        b"foobar",
+        "foobar",
+        io.BytesIO(b"foobar"),
+        [b"foo", b"bar"],
+    ],
+)
+def test_set_response(data):
+    response = Response()
+    response.set_response(data)
+    assert response.get_data() == b"foobar"
+
+
+def test_update_from():
+    original = Response(
+        [b"foo", b"bar"], 202, headers={"X-Foo": "Bar"}, mimetype="application/octet-stream"
+    )
+
+    response = Response()
+    response.update_from(original)
+
+    assert response.get_data() == b"foobar"
+    assert response.status_code == 202
+    assert response.headers.get("X-Foo") == "Bar"
+    assert response.content_type == "application/octet-stream"


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

To develop web apps, we often want to serve static resources.

This PR introduces a simple but powerful utility method that allows you to serve static files from python packages.

Suppose you have module hierarchy:

```
app
├── app.py
├── __init__.py
└── static
    ├── index.html
    ├── style.css
    └── __init__.py
```

You can create simple handler:

```python
from app import static

@route("/static/<path:path>")
def static(self, request: Request, path):
    return Response.from_resource(static, path)
```

When calling `http://localhost/static/style.css` it will serve the file as a webserver would.


<!-- How does Rolo behave differently after this PR? -->
## Changes

* `Response` now has a method `from_resource` that can be used to serve static resources from modules

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
