### PR TITLE
fix restore payload

### DIFF
--- a/rolo/request.py
+++ b/rolo/request.py
@@ -295,10 +295,7 @@ def restore_payload(request: Request) -> bytes:
     if request.method != "POST":
         return data
 
-    if request.form and not request.files:
-        data += urlencode(list(request.form.items(multi=True))).encode("utf-8")
-
-    elif request.files:
+    if request.mimetype == "multipart/form-data":
         boundary = request.content_type.split("=")[1]
 
         fields = MultiDict()
@@ -307,5 +304,8 @@ def restore_payload(request: Request) -> bytes:
 
         _, data_files = encode_multipart(fields, boundary)
         data += data_files
+
+    elif request.mimetype == "application/x-www-form-urlencoded":
+        data += urlencode(list(request.form.items(multi=True))).encode("utf-8")
 
     return data

--- a/rolo/request.py
+++ b/rolo/request.py
@@ -295,12 +295,10 @@ def restore_payload(request: Request) -> bytes:
     if request.method != "POST":
         return data
 
-    # TODO: check how request that encode both files and form are really serialized (not sure this works this way)
-
-    if request.form:
+    if request.form and not request.files:
         data += urlencode(list(request.form.items(multi=True))).encode("utf-8")
 
-    if request.files:
+    elif request.files:
         boundary = request.content_type.split("=")[1]
 
         fields = MultiDict()

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -3,7 +3,7 @@ import wsgiref.validate
 import pytest
 from werkzeug.exceptions import BadRequest
 
-from rolo.request import Request, dummy_wsgi_environment, get_raw_path
+from rolo.request import Request, dummy_wsgi_environment, get_raw_path, restore_payload
 
 
 def test_get_json():
@@ -206,3 +206,105 @@ def test_utf8_path():
 
     assert r.path == "/foo/Ā0Ä"
     assert r.environ["PATH_INFO"] == "/foo/Ä\x800Ã\x84"  # quoted and latin-1 encoded
+
+
+def test_restore_payload_multipart_parsing():
+    body = (
+        b'\r\n'
+        b'--4efd159eae0c4f4e125a5a509e073d85'
+        b'\r\n'
+        b'Content-Disposition: form-data; name="formfield"'
+        b'\r\n\r\n'
+        b'not a file, just a field'
+        b'\r\n'
+        b"--4efd159eae0c4f4e125a5a509e073d85"
+        b"\r\n"
+        b'Content-Disposition: form-data; name="foo"; filename="foo"'
+        b"\r\n"
+        b"Content-Type: text/plain;"
+        b"\r\n\r\n"
+        b"bar"
+        b"\r\n"
+        b"--4efd159eae0c4f4e125a5a509e073d85"
+        b"\r\n"
+        b'Content-Disposition: form-data; name="baz"; filename="baz"'
+        b"\r\n"
+        b"Content-Type: text/plain;"
+        b"\r\n\r\n"
+        b"ed"
+        b'\r\n'
+        b"\r\n--4efd159eae0c4f4e125a5a509e073d85--"
+        b"\r\n"
+    )
+
+    request = Request(
+        "POST",
+        path="/",
+        body=body,
+        headers={"Content-Type": "multipart/form-data; boundary=4efd159eae0c4f4e125a5a509e073d85"},
+    )
+
+    form = {}
+    for k, field in request.form.items():
+        form[k] = field
+
+    assert form == {"formfield": "not a file, just a field"}
+
+    files = []
+    for k, file_storage in request.files.items():
+        assert file_storage.stream
+        # we do not want to consume the file storage stream, because we can't restore the payload then
+        files.append(k)
+
+    assert files == ["foo", "baz"]
+    restored_data = restore_payload(request)
+
+    assert restored_data == body
+
+
+def test_request_mixed_multipart():
+    # this is how we previously restored a form that would have both `form` fields and `files`
+    # we would URL encode the form first then add multipart, which does not work, the first part should be ignored
+    # and make certain strict multipart parser fail (Starlette), because it finds data before the first boundary
+    body = (
+        b'formfield=not+a+file%2C+just+a+field\r\nn'
+        b"--4efd159eae0c4f4e125a5a509e073d85"
+        b"\r\n"
+        b'Content-Disposition: form-data; name="foo"; filename="foo"'
+        b"\r\n"
+        b"Content-Type: text/plain;"
+        b"\r\n\r\n"
+        b"bar"
+        b"\r\n"
+        b"--4efd159eae0c4f4e125a5a509e073d85"
+        b"\r\n"
+        b'Content-Disposition: form-data; name="baz"; filename="baz"'
+        b"\r\n"
+        b"Content-Type: text/plain;"
+        b"\r\n\r\n"
+        b"ed"
+        b'\r\n'
+        b"\r\n--4efd159eae0c4f4e125a5a509e073d85--"
+        b"\r\n"
+    )
+
+    request = Request(
+        "POST",
+        path="/",
+        body=body,
+        headers={"Content-Type": "multipart/form-data; boundary=4efd159eae0c4f4e125a5a509e073d85"},
+    )
+
+    form = {}
+    for k, field in request.form.items():
+        form[k] = field
+
+    assert form == {}
+
+    files = []
+    for k, file_storage in request.files.items():
+        assert file_storage.stream
+        # we do not want to consume the file storage stream, because we can't restore the payload then
+        files.append(k)
+
+    assert files == ["foo", "baz"]


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This issue was reported in a support case.

Their use case was to send a multipart form over to API Gateway v2, forwarding that to ELB itself forwarding to an ECS Fargate container. 

This was failing because the FastAPI API running inside the ECS container could not parse the form anymore with the following issue: `Did not find boundary character 112 at index 2`

Looking far and deep, I could point the issue back to the multiple calls to `restore_payload` along the way. 

We would both encode the `form` fields in a `application/x-www-form-urlencoded` way and then once again encode them in a `multipart/form-data` way if there was also files in the form. 

We can fix that the same way Werkzeug is parsing the form:
```python
if mimetype == "multipart/form-data":
    parse_func = self._parse_multipart
elif mimetype == "application/x-www-form-urlencoded":
    parse_func = self._parse_urlencoded
```

So reversing this to encode back the request should work as well.

Looking at the RFC: https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html, it seems Starlette might be a bit too strict while parsing the multipart (the URL encoded form part could have been considered as a preamble, which is why we didn't see the issue earlier, Werkzeug just ignores it). 

Looking at this incoming request containing a form field `formfield` and file `foo`:
```bytes
\r\n
--4efd159eae0c4f4e125a5a509e073d85
\r\n
Content-Disposition: form-data; name="formfield"
\r\n\r\n
not a file just a field
\r\n
--4efd159eae0c4f4e125a5a509e073d85
\r\n
Content-Disposition: form-data; name="foo"; filename="foo"
\r\n
Content-Type: text/plain;
\r\n\r\n
bar
\r\n
\r\n--4efd159eae0c4f4e125a5a509e073d85--
\r\n
```

We would have restored it that way:
```bytes
formfield=not+a+file%2C+just+a+field\r\n
--4efd159eae0c4f4e125a5a509e073d85
\r\n
Content-Disposition: form-data; name="formfield"
\r\n\r\n
not a file just a field
\r\n
--4efd159eae0c4f4e125a5a509e073d85
\r\n
Content-Disposition: form-data; name="foo"; filename="foo"
\r\n
Content-Type: text/plain;
\r\n\r\n
bar
\r\n
\r\n--4efd159eae0c4f4e125a5a509e073d85--
\r\n
```

We can see it added the url encoded values of the form above the multipart data. 

<!-- How does Rolo behave differently after this PR? -->
## Changes
- look at the mime type of the request to re-encode the form (and files) into bytes data. 
- add a few tests to verify the behavior

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
