### PR TITLE
add support for pydantic in the handler dispatcher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,4 +76,12 @@ exclude = [
     "target",
     "*.egg-info",
     ".git",
-    ]
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "if __name__ == .__main__.:",
+    "raise NotImplemented.",
+    "return NotImplemented",
+    "def __repr__",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "black==23.10.0",
     "pytest>=7.0",
     "hypercorn",
+    "pydantic",
     "pytest_httpserver",
     "websocket-client>=1.7.0",
     "coverage[toml]>=5.0.0",

--- a/rolo/dispatcher.py
+++ b/rolo/dispatcher.py
@@ -1,11 +1,22 @@
+import inspect
 import json
-from typing import Any, Dict, Protocol, Type, Union
+import logging
+from typing import Any, Dict, Optional, Protocol, Type, Union
 
 from werkzeug import Response as WerkzeugResponse
+
+try:
+    import pydantic
+
+    ENABLE_PYDANTIC = True
+except ImportError:
+    ENABLE_PYDANTIC = False
 
 from .request import Request
 from .response import Response
 from .router import Dispatcher, RequestArguments
+
+LOG = logging.getLogger(__name__)
 
 ResultValue = Union[
     WerkzeugResponse,
@@ -60,6 +71,34 @@ class Handler(Protocol):
         raise NotImplementedError
 
 
+def _try_parse_pydantic_request_body(request: Request, endpoint: Handler) -> Optional[dict]:
+    if not request.content_length:
+        return None
+
+    if not inspect.isfunction(endpoint) and not inspect.ismethod(endpoint):
+        # cannot yet dispatch to other callables (e.g. an object with a `__call__` method)
+        return None
+
+    # finds the first pydantic.BaseModel in the list of annotations.
+    # ``def foo(request: Request, id: int, item: MyItem)`` would yield ``('my_item', MyItem)``
+    arg_name = None
+    arg_type = None
+    for k, v in endpoint.__annotations__.items():
+        if issubclass(v, pydantic.BaseModel):
+            arg_name = k
+            arg_type = v
+            break
+
+    if arg_type is None:
+        return None
+
+    # TODO: error handling
+    obj = request.get_json(force=True)
+
+    # TODO: error handling
+    return {arg_name: arg_type.model_validate(obj)}
+
+
 def handler_dispatcher(json_encoder: Type[json.JSONEncoder] = None) -> Dispatcher[Handler]:
     """
     Creates a Dispatcher that treats endpoints like callables of the ``Handler`` Protocol.
@@ -69,9 +108,22 @@ def handler_dispatcher(json_encoder: Type[json.JSONEncoder] = None) -> Dispatche
     """
 
     def _dispatch(request: Request, endpoint: Handler, args: RequestArguments) -> Response:
-        result = endpoint(request, **args)
+        if ENABLE_PYDANTIC:
+            try:
+                kwargs = _try_parse_pydantic_request_body(request, endpoint) or {}
+                result = endpoint(request, **{**args, **kwargs})
+            except pydantic.ValidationError as e:
+                return Response(e.json(), mimetype="application/json", status=400)
+
+            if isinstance(result, pydantic.BaseModel):
+                result = result.model_dump()
+
+        else:
+            result = endpoint(request, **args)
+
         if isinstance(result, WerkzeugResponse):
             return result
+
         response = Response()
         if result is not None:
             _populate_response(response, result, json_encoder)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict
 
+import pydantic
 import pytest
 from werkzeug.exceptions import NotFound
 
@@ -80,3 +81,65 @@ class TestHandlerDispatcher:
 
         router.add("/", handler)
         assert router.dispatch(Request("GET", "/")).status_code == 200
+
+
+class TestPydanticHandlerDispatcher:
+    def test_request_arg(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        class MyItem(pydantic.BaseModel):
+            name: str
+            price: float
+            is_offer: bool = None
+
+        def handler(_request: Request, item_id: int, item: MyItem) -> str:
+            return item.model_dump_json()
+
+        router.add("/items/<item_id>", handler)
+
+        request = Request("POST", "/items/123", body=b'{"name":"rolo","price":420.69}')
+        assert router.dispatch(request).data == b'{"name":"rolo","price":420.69,"is_offer":null}'
+
+    def test_response(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        class MyItem(pydantic.BaseModel):
+            name: str
+            price: float
+            is_offer: bool = None
+
+        def handler(_request: Request, item_id: int) -> MyItem:
+            return MyItem(name="rolo", price=420.69)
+
+        router.add("/items/<item_id>", handler)
+
+        request = Request("GET", "/items/123")
+        assert router.dispatch(request).get_json() == {
+            "name": "rolo",
+            "price": 420.69,
+            "is_offer": None,
+        }
+
+    def test_request_arg_validation_error(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        class MyItem(pydantic.BaseModel):
+            name: str
+            price: float
+            is_offer: bool = None
+
+        def handler(_request: Request, item_id: int, item: MyItem) -> str:
+            return item.model_dump_json()
+
+        router.add("/items/<item_id>", handler)
+
+        request = Request("POST", "/items/123", body=b'{"name":"rolo"}')
+        assert router.dispatch(request).get_json() == [
+            {
+                "type": "missing",
+                "loc": ["price"],
+                "msg": "Field required",
+                "input": {"name": "rolo"},
+                "url": "https://errors.pydantic.dev/2.8/v/missing",
+            }
+        ]

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -1,0 +1,157 @@
+import pydantic
+import pytest
+
+from rolo import Request, Router, dispatcher, resource
+from rolo.dispatcher import handler_dispatcher
+
+
+class MyItem(pydantic.BaseModel):
+    name: str
+    price: float
+    is_offer: bool = None
+
+
+class TestPydanticHandlerDispatcher:
+    def test_request_arg(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request, item: MyItem) -> dict:
+            return {"item": item.model_dump()}
+
+        router.add("/items", handler)
+
+        request = Request("POST", "/items", body=b'{"name":"rolo","price":420.69}')
+        assert router.dispatch(request).get_json(force=True) == {
+            "item": {
+                "name": "rolo",
+                "price": 420.69,
+                "is_offer": None,
+            },
+        }
+
+    def test_request_args(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request, item_id: int, item: MyItem) -> dict:
+            return {"item_id": item_id, "item": item.model_dump()}
+
+        router.add("/items/<int:item_id>", handler)
+
+        request = Request("POST", "/items/123", body=b'{"name":"rolo","price":420.69}')
+        assert router.dispatch(request).get_json(force=True) == {
+            "item_id": 123,
+            "item": {
+                "name": "rolo",
+                "price": 420.69,
+                "is_offer": None,
+            },
+        }
+
+    def test_request_args_empty_body(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request, item_id: int, item: MyItem) -> dict:
+            return {"item_id": item_id, "item": item.model_dump()}
+
+        router.add("/items/<int:item_id>", handler)
+
+        request = Request("POST", "/items/123", body=b"")
+        assert router.dispatch(request).get_json(force=True) == [
+            {
+                "type": "json_invalid",
+                "loc": [],
+                "msg": "Invalid JSON: EOF while parsing a value at line 1 column 0",
+                "ctx": {"error": "EOF while parsing a value at line 1 column 0"},
+                "input": "",
+                "url": "https://errors.pydantic.dev/2.8/v/json_invalid",
+            }
+        ]
+
+    def test_response(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request, item_id: int) -> MyItem:
+            return MyItem(name="rolo", price=420.69)
+
+        router.add("/items/<int:item_id>", handler)
+
+        request = Request("GET", "/items/123")
+        assert router.dispatch(request).get_json() == {
+            "name": "rolo",
+            "price": 420.69,
+            "is_offer": None,
+        }
+
+    def test_request_arg_validation_error(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request, item_id: int, item: MyItem) -> str:
+            return item.model_dump_json()
+
+        router.add("/items/<int:item_id>", handler)
+
+        request = Request("POST", "/items/123", body=b'{"name":"rolo"}')
+        assert router.dispatch(request).get_json() == [
+            {
+                "type": "missing",
+                "loc": ["price"],
+                "msg": "Field required",
+                "input": {"name": "rolo"},
+                "url": "https://errors.pydantic.dev/2.8/v/missing",
+            }
+        ]
+
+    def test_missing_annotation(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        # without an annotation, we cannot be sure what type to serialize into, so the dispatcher doesn't pass
+        # anything into ``item``.
+        def handler(_request: Request, item=None) -> dict:
+            return {"item": item}
+
+        router.add("/items", handler)
+
+        request = Request("POST", "/items", body=b'{"name":"rolo","price":420.69}')
+        assert router.dispatch(request).get_json(force=True) == {"item": None}
+
+    def test_with_pydantic_disabled(self, monkeypatch):
+        monkeypatch.setattr(dispatcher, "ENABLE_PYDANTIC", False)
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request, item: MyItem) -> dict:
+            return {"item": item.model_dump()}
+
+        router.add("/items", handler)
+
+        request = Request("POST", "/items", body=b'{"name":"rolo","price":420.69}')
+        with pytest.raises(TypeError):
+            # "missing 1 required positional argument: 'item'"
+            assert router.dispatch(request)
+
+    def test_with_resource(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        @resource("/items/<int:item_id>")
+        class MyResource:
+            def on_get(self, request: Request, item_id: int):
+                return MyItem(name="rolo", price=420.69)
+
+            def on_post(self, request: Request, item_id: int, item: MyItem):
+                return {"item_id": item_id, "item": item.model_dump()}
+
+        router.add(MyResource())
+
+        response = router.dispatch(Request("GET", "/items/123"))
+        assert response.get_json() == {
+            "name": "rolo",
+            "price": 420.69,
+            "is_offer": None,
+        }
+
+        response = router.dispatch(
+            Request("POST", "/items/123", body=b'{"name":"rolo","price":420.69}')
+        )
+        assert response.get_json() == {
+            "item": {"is_offer": None, "name": "rolo", "price": 420.69},
+            "item_id": 123,
+        }


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

This PR adds a feature that is inspired by FastAPIs integration with pydantic. You can now add pydantic models to the annotation signature of your route/resource method, which will be picked up by the handler dispatcher and automatically parses the request body as json and maps it to the pydantic model.

Here is a simple example:

```python
class MyItem(pydantic.BaseModel):
    name: str
    price: float
    is_offer: bool = None

@route("/items/<item_id>", methods=["POST"])
def add_item(request: Request, item_id: int, item: MyItem) -> str:
    print(item.name, item.price)
    return "ok"

@route("/items/<item_id>", methods=["GET"])
def get_item(request: Request, item_id: int) -> MyItem:
    return MyItem(name="rolo", price=4.20)
```

The dispatcher searches the type hints of the function for the first class that is a subclass of `pydantic.BaseModel`, and uses that to serialize the request body into. The parameter can be placed anywhere in the signature (doesn't have to be at the end).

Error handling (input validation) is handled similarly as in FastAPI, it simply serializes the `pydantic.ValidationError` into json.

See the added test for how it behaves.

Thanks to @Morijarti for the suggestion!

<!-- How does Rolo behave differently after this PR? -->
## Changes

* If pydantic is installed, the `handler_dispatcher` now automatically parses and dispatches pydantic models as request and response arguments

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
## TODO

What's left to do:

- [x] Increase test coverage
- [x] Add to README
- [x] Test with other route mechanisms like `@resource`

