### PR TITLE
fix pydantic return type serializer to support lists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "rolo"
 authors = [
     { name = "LocalStack Contributors", email = "info@localstack.cloud" }
 ]
-version = "0.6.0"
+version = "0.6.1"
 description = "A Python framework for building HTTP-based server applications"
 dependencies = [
     "requests>=2.20",

--- a/rolo/dispatcher.py
+++ b/rolo/dispatcher.py
@@ -120,6 +120,14 @@ def handler_dispatcher(json_encoder: Type[json.JSONEncoder] = None) -> Dispatche
 
             if isinstance(result, pydantic.BaseModel):
                 result = result.model_dump()
+            if isinstance(result, (list, tuple)):
+                converted = []
+                for element in result:
+                    if isinstance(element, pydantic.BaseModel):
+                        converted.append(element.model_dump())
+                    else:
+                        converted.append(element)
+                result = converted
 
         else:
             result = endpoint(request, **args)

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -82,6 +82,31 @@ class TestPydanticHandlerDispatcher:
             "is_offer": None,
         }
 
+    def test_response_list(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request) -> list[MyItem]:
+            return [
+                MyItem(name="rolo", price=420.69),
+                MyItem(name="twiks", price=1.23, is_offer=True),
+            ]
+
+        router.add("/items", handler)
+
+        request = Request("GET", "/items")
+        assert router.dispatch(request).get_json() == [
+            {
+                "name": "rolo",
+                "price": 420.69,
+                "is_offer": None,
+            },
+            {
+                "name": "twiks",
+                "price": 1.23,
+                "is_offer": True,
+            },
+        ]
+
     def test_request_arg_validation_error(self):
         router = Router(dispatcher=handler_dispatcher())
 


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

I forgot to handle lists of pydantic models in #14. You can now do something like:

```python
@route("/items")
def handler(_request: Request) -> list[MyItem]:
    return [
        MyItem(name="rolo", ...),
        MyItem(name="twiks", ...),
    ]
```

<!-- How does Rolo behave differently after this PR? -->
## Changes

* lists of pydantic models can now be returned from a handler using a `handler_dispatcher`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
