### PR TITLE
add parameter to control redirects

### DIFF
--- a/rolo/client.py
+++ b/rolo/client.py
@@ -56,9 +56,11 @@ class _VerifyRespectingSession(requests.Session):
 
 class SimpleRequestsClient(HttpClient):
     session: requests.Session
+    follow_redirects: bool
 
-    def __init__(self, session: requests.Session = None):
+    def __init__(self, session: requests.Session = None, follow_redirects: bool = True):
         self.session = session or _VerifyRespectingSession()
+        self.follow_redirects = follow_redirects
 
     @staticmethod
     def _get_destination_url(request: Request, server: str | None = None) -> str:
@@ -73,9 +75,7 @@ class SimpleRequestsClient(HttpClient):
 
         return get_raw_base_url(request)
 
-    def request(
-        self, request: Request, server: str | None = None, allow_redirects=True
-    ) -> Response:
+    def request(self, request: Request, server: str | None = None) -> Response:
         """
         Very naive implementation to make the given HTTP request using the requests library, i.e., process the request
         as a client.
@@ -109,7 +109,7 @@ class SimpleRequestsClient(HttpClient):
             headers=headers,
             data=restore_payload(request),
             stream=True,
-            allow_redirects=allow_redirects,
+            allow_redirects=self.follow_redirects,
         )
 
         if request.method == "HEAD":

--- a/rolo/client.py
+++ b/rolo/client.py
@@ -73,13 +73,16 @@ class SimpleRequestsClient(HttpClient):
 
         return get_raw_base_url(request)
 
-    def request(self, request: Request, server: str | None = None) -> Response:
+    def request(
+        self, request: Request, server: str | None = None, allow_redirects=True
+    ) -> Response:
         """
         Very naive implementation to make the given HTTP request using the requests library, i.e., process the request
         as a client.
 
         :param request: the request to perform
         :param server: the URL to send the request to, which defaults to the host component of the original Request.
+        :param allow_redirects: allow the request to follow redirects
         :return: the response.
         """
 
@@ -106,6 +109,7 @@ class SimpleRequestsClient(HttpClient):
             headers=headers,
             data=restore_payload(request),
             stream=True,
+            allow_redirects=allow_redirects,
         )
 
         if request.method == "HEAD":


### PR DESCRIPTION
## Motivation
Currently, the ELB service relies on this library; however, to ensure that the WordPress scenario functions correctly ( trying to go through the installation process), the 302 responses and other redirects should be returned to the client rather than being handled by the internal HTTP client.

## Changes
- add new parameter to the request method
