### PR TITLE
add workaround for Twisted when receiving absolute-form URI in HTTP request

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
     "websocket-client>=1.7.0",
     "coverage[toml]>=5.0.0",
     "coveralls>=3.3",
-    "twisted>=24",
+    "localstack-twisted",
     "ruff==0.1.0"
 ]
 docs = [

--- a/rolo/gateway/wsgi.py
+++ b/rolo/gateway/wsgi.py
@@ -36,7 +36,6 @@ class WsgiGateway:
             environ.get("HTTP_HOST"),
             environ.get("RAW_URI"),
         )
-        print(f"{environ=}")
         request = Request(environ)
 
         raw_headers = environ.get("rolo.headers") or environ.get("asgi.headers")

--- a/rolo/gateway/wsgi.py
+++ b/rolo/gateway/wsgi.py
@@ -36,6 +36,7 @@ class WsgiGateway:
             environ.get("HTTP_HOST"),
             environ.get("RAW_URI"),
         )
+        print(f"{environ=}")
         request = Request(environ)
 
         raw_headers = environ.get("rolo.headers") or environ.get("asgi.headers")

--- a/rolo/serving/twisted.py
+++ b/rolo/serving/twisted.py
@@ -62,7 +62,7 @@ def update_wsgi_environment(environ: "WSGIEnvironment", request: TwistedRequest)
     # TODO: check if twisted input streams are really properly terminated
     # this is needed for streaming requests
     environ["wsgi.input_terminated"] = True
-
+    print(f"update_wsgi_environment {environ=}")
     # create RAW_URI and REQUEST_URI
     environ["REQUEST_URI"] = request.uri.decode("utf-8")
     environ["RAW_URI"] = request.uri.decode("utf-8")
@@ -164,7 +164,6 @@ class HeaderPreservingHTTPChannel(HTTPChannel):
     def headerReceived(self, line):
         if not super().headerReceived(line):
             return False
-
         # remember casing of headers for requests
         header, data = line.split(b":", 1)
         request: TwistedRequestAdapter = self.requests[-1]

--- a/rolo/serving/twisted.py
+++ b/rolo/serving/twisted.py
@@ -64,17 +64,17 @@ def update_wsgi_environment(environ: "WSGIEnvironment", request: TwistedRequest)
     environ["wsgi.input_terminated"] = True
 
     if not request.path.startswith(b"/"):
-        # TODO: this is a bug in Twisted: when the HTTP request contains an full absolute-form URI instead of just the
-        #  path (when a request is proxied), the `PATH_INFO` is wrong, as Twisted will use the full URI as a path.
+        # TODO: this is a bug in Twisted: when the HTTP request contains a full absolute-form URI (when a request is
+        #  proxied) instead of a relative path, the `PATH_INFO` is wrong, as Twisted will use the full URI as the path.
         #  `twisted.web.wsgi` will even replace the first char with a slash, leading to something looking like
         #  '/ttp://sns.eu-central-1.amazonaws.com/'
         # See RFC7230: https://tools.ietf.org/html/rfc7230#section-5.3.2
-        # When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below),
-        # a client MUST send the target URI in absolute-form as the request-target.... An example absolute-form
-        # of request-line would be:
-        # GET http://www.example.org/pub/WWW/TheProject.html HTTP/1.1
+        # > When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below),
+        # > a client MUST send the target URI in absolute-form as the request-target.... An example absolute-form
+        # > of request-line would be:
+        # > GET http://www.example.org/pub/WWW/TheProject.html HTTP/1.1
         #
-        # we need to fix upstream, but this is a global workaround for now
+        # we need to fix it upstream, but this is a global workaround for now
         environ["PATH_INFO"] = urlparse(request.path).path.decode("utf-8")
 
     # create RAW_URI and REQUEST_URI

--- a/rolo/serving/twisted.py
+++ b/rolo/serving/twisted.py
@@ -10,7 +10,7 @@ from twisted.internet import reactor
 from twisted.internet.protocol import Protocol
 from twisted.protocols.policies import ProtocolWrapper
 from twisted.python.components import proxyForInterface
-from twisted.web.http import HTTPChannel, _GenericHTTPChannelProtocol
+from twisted.web.http import HTTPChannel, _GenericHTTPChannelProtocol, urlparse
 from twisted.web.http_headers import Headers as TwistedHeaders
 from twisted.web.resource import IResource
 from twisted.web.server import NOT_DONE_YET, Request, Site
@@ -62,7 +62,21 @@ def update_wsgi_environment(environ: "WSGIEnvironment", request: TwistedRequest)
     # TODO: check if twisted input streams are really properly terminated
     # this is needed for streaming requests
     environ["wsgi.input_terminated"] = True
-    print(f"update_wsgi_environment {environ=}")
+
+    if not request.path.startswith(b"/"):
+        # TODO: this is a bug in Twisted: when the HTTP request contains an full absolute-form URI instead of just the
+        #  path (when a request is proxied), the `PATH_INFO` is wrong, as Twisted will use the full URI as a path.
+        #  `twisted.web.wsgi` will even replace the first char with a slash, leading to something looking like
+        #  '/ttp://sns.eu-central-1.amazonaws.com/'
+        # See RFC7230: https://tools.ietf.org/html/rfc7230#section-5.3.2
+        # When making a request to a proxy, other than a CONNECT or server-wide OPTIONS request (as detailed below),
+        # a client MUST send the target URI in absolute-form as the request-target.... An example absolute-form
+        # of request-line would be:
+        # GET http://www.example.org/pub/WWW/TheProject.html HTTP/1.1
+        #
+        # we need to fix upstream, but this is a global workaround for now
+        environ["PATH_INFO"] = urlparse(request.path).path.decode("utf-8")
+
     # create RAW_URI and REQUEST_URI
     environ["REQUEST_URI"] = request.uri.decode("utf-8")
     environ["RAW_URI"] = request.uri.decode("utf-8")

--- a/tests/serving/test_twisted.py
+++ b/tests/serving/test_twisted.py
@@ -1,9 +1,10 @@
 import http.client
 import io
+import json
 
 import requests
 
-from rolo import Request, Response, Router, route
+from rolo import Request, Router, route
 from rolo.dispatcher import handler_dispatcher
 from rolo.gateway import Gateway
 from rolo.gateway.handlers import RouterHandler
@@ -31,10 +32,7 @@ def test_full_absolute_form_uri(serve_twisted_gateway):
 
     @route("/hello", methods=["GET"])
     def hello(request: Request):
-        if not request.path == "/hello" or not request.environ["RAW_URI"].startswith("http"):
-            return Response(status=500)
-
-        return "ok"
+        return {"path": request.path, "raw_uri": request.environ["RAW_URI"]}
 
     router.add(hello)
 
@@ -51,3 +49,6 @@ def test_full_absolute_form_uri(serve_twisted_gateway):
     response = conn.getresponse()
 
     assert response.status == 200
+    response_data = json.loads(response.read())
+    assert response_data["path"] == "/hello"
+    assert response_data["raw_uri"].startswith("http")

--- a/tests/serving/test_twisted.py
+++ b/tests/serving/test_twisted.py
@@ -1,5 +1,5 @@
+import http.client
 import io
-import sys
 
 import requests
 
@@ -27,8 +27,6 @@ def test_large_file_upload(serve_twisted_gateway):
 
 
 def test_full_absolute_form_uri(serve_twisted_gateway):
-    import http.client
-
     router = Router(handler_dispatcher())
 
     @route("/hello", methods=["GET"])
@@ -44,11 +42,7 @@ def test_full_absolute_form_uri(serve_twisted_gateway):
     server = serve_twisted_gateway(gateway)
     host = server.url
 
-    if sys.platform.startswith("darwin"):
-        # macOS doesn't like `localhost` and has trouble resolving it
-        conn = http.client.HTTPConnection("", port=server.port)
-    else:
-        conn = http.client.HTTPConnection(host)
+    conn = http.client.HTTPConnection(host="127.0.0.1", port=server.port)
 
     # This is what is sent:
     # send: b'GET http://localhost:<port>/hello HTTP/1.1\r\nHost: localhost:<port>\r\nAccept-Encoding: identity\r\n\r\n'

--- a/tests/serving/test_twisted.py
+++ b/tests/serving/test_twisted.py
@@ -1,10 +1,8 @@
 import io
-import time
 
 import requests
-import urllib3
 
-from rolo import Request, Router, route, Response
+from rolo import Request, Response, Router, route
 from rolo.dispatcher import handler_dispatcher
 from rolo.gateway import Gateway
 from rolo.gateway.handlers import RouterHandler
@@ -29,6 +27,7 @@ def test_large_file_upload(serve_twisted_gateway):
 
 def test_full_absolute_form_uri(serve_twisted_gateway):
     import http.client
+
     router = Router(handler_dispatcher())
 
     @route("/hello", methods=["GET"])
@@ -48,7 +47,7 @@ def test_full_absolute_form_uri(serve_twisted_gateway):
     # This is what is sent:
     # send: b'GET http://localhost:<port>/hello HTTP/1.1\r\nHost: localhost:<port>\r\nAccept-Encoding: identity\r\n\r\n'
     # note the full URI in the HTTP request
-    conn.request("GET", url=f"{host}/hello",)
+    conn.request("GET", url=f"{host}/hello")
     response = conn.getresponse()
 
     assert response.status == 200

--- a/tests/serving/test_twisted.py
+++ b/tests/serving/test_twisted.py
@@ -1,8 +1,10 @@
 import io
+import time
 
 import requests
+import urllib3
 
-from rolo import Request, Router, route
+from rolo import Request, Router, route, Response
 from rolo.dispatcher import handler_dispatcher
 from rolo.gateway import Gateway
 from rolo.gateway.handlers import RouterHandler
@@ -23,3 +25,29 @@ def test_large_file_upload(serve_twisted_gateway):
     response = requests.post(server.url + "/hello", io.BytesIO(b"0" * 100001))
 
     assert response.status_code == 200
+
+
+def test_full_absolute_form_uri(serve_twisted_gateway):
+    import http.client
+    router = Router(handler_dispatcher())
+
+    @route("/hello", methods=["GET"])
+    def hello(request: Request):
+        if not request.path == "/hello":
+            return Response(status=500)
+        return "ok"
+
+    router.add(hello)
+
+    gateway = Gateway(request_handlers=[RouterHandler(router, True)])
+    server = serve_twisted_gateway(gateway)
+    host = server.url
+    conn = http.client.HTTPConnection("", port=server.port)
+    conn.set_debuglevel(1)
+    # This is what is sent:
+    # send: b'GET http://localhost:<port>/hello HTTP/1.1\r\nHost: localhost:<port>\r\nAccept-Encoding: identity\r\n\r\n'
+    # note the full URI in the HTTP request
+    conn.request("GET", url=f"{host}/hello",)
+    response = conn.getresponse()
+
+    assert response.status == 200

--- a/tests/serving/test_twisted.py
+++ b/tests/serving/test_twisted.py
@@ -33,8 +33,9 @@ def test_full_absolute_form_uri(serve_twisted_gateway):
 
     @route("/hello", methods=["GET"])
     def hello(request: Request):
-        if not request.path == "/hello":
+        if not request.path == "/hello" or not request.environ["RAW_URI"].startswith("http"):
             return Response(status=500)
+
         return "ok"
 
     router.add(hello)

--- a/tests/serving/test_twisted.py
+++ b/tests/serving/test_twisted.py
@@ -1,4 +1,5 @@
 import io
+import sys
 
 import requests
 
@@ -42,8 +43,13 @@ def test_full_absolute_form_uri(serve_twisted_gateway):
     gateway = Gateway(request_handlers=[RouterHandler(router, True)])
     server = serve_twisted_gateway(gateway)
     host = server.url
-    conn = http.client.HTTPConnection("", port=server.port)
-    conn.set_debuglevel(1)
+
+    if sys.platform.startswith("darwin"):
+        # macOS doesn't like `localhost` and has trouble resolving it
+        conn = http.client.HTTPConnection("", port=server.port)
+    else:
+        conn = http.client.HTTPConnection(host)
+
     # This is what is sent:
     # send: b'GET http://localhost:<port>/hello HTTP/1.1\r\nHost: localhost:<port>\r\nAccept-Encoding: identity\r\n\r\n'
     # note the full URI in the HTTP request

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -8,6 +8,8 @@ from rolo import Request, Router, resource
 from rolo.routing import handler as routing_handler
 from rolo.routing import handler_dispatcher
 
+pydantic_version = pydantic.version.version_short()
+
 
 class MyItem(pydantic.BaseModel):
     name: str
@@ -67,7 +69,7 @@ class TestPydanticHandlerDispatcher:
                 "msg": "Invalid JSON: EOF while parsing a value at line 1 column 0",
                 "ctx": {"error": "EOF while parsing a value at line 1 column 0"},
                 "input": "",
-                "url": "https://errors.pydantic.dev/2.8/v/json_invalid",
+                "url": f"https://errors.pydantic.dev/{pydantic_version}/v/json_invalid",
             }
         ]
 
@@ -126,7 +128,7 @@ class TestPydanticHandlerDispatcher:
                 "loc": ["price"],
                 "msg": "Field required",
                 "input": {"name": "rolo"},
-                "url": "https://errors.pydantic.dev/2.8/v/missing",
+                "url": f"https://errors.pydantic.dev/{pydantic_version}/v/missing",
             }
         ]
 


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
As reported by https://github.com/localstack/localstack/issues/11652, we've had an issue in LocalStack because the request would contain the whole URI in the `request.path`. 

This can be traced down to Twisted with a simple reproducer:
```python
from twisted.web import server, resource
from twisted.internet import reactor

class Simple(resource.Resource):
    isLeaf = True
    def render_POST(self, request):
        print(f"{request.path=}")
        return "<html>Hello, world!</html>"

site = server.Site(Simple())
reactor.listenTCP(4566, site)
reactor.run()
```

Sending a request with an absolute-form URI (see RFC7230: https://tools.ietf.org/html/rfc7230#section-5.3.2) like `GET http://localhost:4566/path HTTP/1.1` will print `request.path=http://localhost:4566/path`.

When using the WSGI compatible part of twisted, it will even replace the first char by `/`, leading to `PATH_INFO` in the environ to be `/ttp://localhost:4566/path`. 

This is only a workaround until we can fix it in Twisted directly, and if they're open to it. 
Seems an issue was opened in 2010 about it: https://github.com/twisted/twisted/issues/4371

<!-- How does Rolo behave differently after this PR? -->
## Changes
- add a quick check if the path does not start by `/`, which is something we've been doing directly on the `RAW_URI` in LocalStack for a while now (with https://github.com/localstack/localstack/pull/8962). 
- add a test sending a full absolute-form URI to the Twisted gateway and assert the path is correct (you can remove the fix to see what it gives without it)
- make tests use `localstack-twisted` because it seems Twisted changed the logic around the casing of headers to use a `_NameEncoder`, which breaks our logic to preserve header casing. See https://github.com/localstack/rolo/actions/runs/11298814586/job/31428556695?pr=23 and https://github.com/twisted/twisted/pull/12264

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
