### PR TITLE
remove Transfer-Encoding from Proxy responses

### DIFF
--- a/rolo/client.py
+++ b/rolo/client.py
@@ -126,6 +126,13 @@ class SimpleRequestsClient(HttpClient):
         response_headers = Headers(dict(response.headers))
         if "chunked" in response_headers.get("Transfer-Encoding", ""):
             response_headers.pop("Content-Length", None)
+            # We should not set `Transfer-Encoding` in a Response, because it is the responsibility of the webserver
+            # to do so, if there are no Content-Length. LocalStack is handling gzip behavior, so we keep that one.
+            transfer_encoding = [
+                v for v in response_headers.getlist("Transfer-Encoding")
+                if v.lower() != "chunked"
+            ]
+            response_headers.setlist("Transfer-Encoding", transfer_encoding)
 
         final_response = Response(
             response=(chunk for chunk in response.raw.stream(1024, decode_content=False)),

--- a/rolo/client.py
+++ b/rolo/client.py
@@ -127,7 +127,8 @@ class SimpleRequestsClient(HttpClient):
         if "chunked" in response_headers.get("Transfer-Encoding", ""):
             response_headers.pop("Content-Length", None)
             # We should not set `Transfer-Encoding` in a Response, because it is the responsibility of the webserver
-            # to do so, if there are no Content-Length. LocalStack is handling gzip behavior, so we keep that one.
+            # to do so, if there are no Content-Length. However, gzip behavior is more related to the actual content of
+            # the response, so we keep that one.
             transfer_encoding = [
                 v for v in response_headers.getlist("Transfer-Encoding") if v.lower() != "chunked"
             ]

--- a/rolo/client.py
+++ b/rolo/client.py
@@ -129,8 +129,7 @@ class SimpleRequestsClient(HttpClient):
             # We should not set `Transfer-Encoding` in a Response, because it is the responsibility of the webserver
             # to do so, if there are no Content-Length. LocalStack is handling gzip behavior, so we keep that one.
             transfer_encoding = [
-                v for v in response_headers.getlist("Transfer-Encoding")
-                if v.lower() != "chunked"
+                v for v in response_headers.getlist("Transfer-Encoding") if v.lower() != "chunked"
             ]
             response_headers.setlist("Transfer-Encoding", transfer_encoding)
 

--- a/rolo/client.py
+++ b/rolo/client.py
@@ -124,15 +124,16 @@ class SimpleRequestsClient(HttpClient):
             return final_response
 
         response_headers = Headers(dict(response.headers))
-        if "chunked" in response_headers.get("Transfer-Encoding", ""):
+        if "chunked" in (transfer_encoding := response_headers.get("Transfer-Encoding", "")):
             response_headers.pop("Content-Length", None)
             # We should not set `Transfer-Encoding` in a Response, because it is the responsibility of the webserver
             # to do so, if there are no Content-Length. However, gzip behavior is more related to the actual content of
             # the response, so we keep that one.
-            transfer_encoding = [
-                v for v in response_headers.getlist("Transfer-Encoding") if v.lower() != "chunked"
+            transfer_encoding_values = [v.strip() for v in transfer_encoding.split(",")]
+            transfer_encoding_no_chunked = [
+                v for v in transfer_encoding_values if v.lower() != "chunked"
             ]
-            response_headers.setlist("Transfer-Encoding", transfer_encoding)
+            response_headers.setlist("Transfer-Encoding", transfer_encoding_no_chunked)
 
         final_response = Response(
             response=(chunk for chunk in response.raw.stream(1024, decode_content=False)),

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -181,6 +181,36 @@ class TestPathForwarder:
             "query": "%E4%B8%8A%E6%B5%B7%2B%E4%B8%AD%E5%9C%8B=%E4%B8%8A%E6%B5%B7%2B%E4%B8%AD%E5%9C%8B",
         }
 
+    @pytest.mark.parametrize("chunked", [True, False])
+    def test_proxy_handler_transfer_encoding(self, router_server, httpserver: HTTPServer, chunked):
+        router, proxy = router_server
+        backend = httpserver
+        body = "enough-for-content-length"
+
+        def _handler(_: WerkzeugRequest):
+            # if the response is chunked, return a generator instead, which will return `Transfer-Encoding: chunked`
+            if chunked:
+                _body = (c for c in body)
+            else:
+                _body = body
+
+            return Response(_body, status=200)
+
+        backend.expect_request("").respond_with_handler(_handler)
+
+        router.add("/", ProxyHandler(backend.url_for("/")))
+
+        response = requests.get(proxy.url)
+
+        if chunked:
+            assert response.headers["Transfer-Encoding"] == "chunked"
+            assert "Content-Length" not in response.headers
+        else:
+            assert response.headers["Content-Length"] == str(len(body))
+            assert "Transfer-Encoding" not in response.headers
+
+        assert response.text == body
+
 
 class TestProxy:
     def test_proxy_with_custom_client(self, httpserver: HTTPServer):
@@ -217,12 +247,14 @@ class TestProxy:
     ):
         body = "enough-for-content-length"
 
-        def _handler(_: WerkzeugRequest):
-            headers = (
-                {"Content-Length": len(body)} if not chunked else {"Transfer-Encoding": "chunked"}
-            )
+        def _handler(_request: Request) -> Response:
+            # if the response is chunked, return a generator instead, which will return `Transfer-Encoding: chunked`
+            if chunked:
+                _body = (c for c in body)
+            else:
+                _body = body
 
-            return Response(body, headers=headers)
+            return Response(_body, status=200)
 
         httpserver.expect_request("").respond_with_handler(_handler)
 
@@ -233,11 +265,14 @@ class TestProxy:
         response = proxy.request(request)
 
         if chunked:
-            assert response.headers["Transfer-Encoding"] == "chunked"
+            # the proxy should not return a Transfer-Encoding, as this is something the webserver should set
+            assert "Transfer-Encoding" not in response.headers
             assert "Content-Length" not in response.headers
         else:
             assert response.headers["Content-Length"] == str(len(body))
             assert "Transfer-Encoding" not in response.headers
+
+        assert response.data.decode() == body
 
 
 @pytest.mark.parametrize("consume_data", [True, False])

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -275,7 +275,6 @@ class TestProxy:
 
         assert response.data.decode() == body
 
-
     @pytest.mark.parametrize(
         "chunked,gzipped",
         [
@@ -283,7 +282,7 @@ class TestProxy:
             (False, True),
             (True, False),
             (True, True),
-        ]
+        ],
     )
     def test_proxy_for_transfer_encoding_chunked_and_gzip(
         self,
@@ -303,7 +302,7 @@ class TestProxy:
                 headers["Transfer-Encoding"] = "gzip"
 
             if chunked:
-                _body = (chr(c).encode('latin-1') for c in body)
+                _body = (chr(c).encode("latin-1") for c in body)
 
             return Response(_body, status=200, headers=headers)
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -306,11 +306,11 @@ class TestProxy:
 
             return Response(_body, status=200, headers=headers)
 
-        httpserver.expect_request("").respond_with_handler(_handler)
+        httpserver.expect_request("/proxy").respond_with_handler(_handler)
 
         proxy = Proxy(httpserver.url_for("/").lstrip("/"))
 
-        request = Request(path="/", method="GET", headers={"Host": "127.0.0.1:80"})
+        request = Request(path="/proxy", method="GET", headers={"Host": "127.0.0.1:80"})
 
         response = proxy.request(request)
 


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've had an issue with the Mailhog extension when using HTTP/1.1 (https://github.com/localstack/localstack-extensions/blob/main/mailhog), where the content would get double `Transfer-Encoding: chunked` header.

This was investigated, and we found out that Twisted would always automatically add the `Transfer-Encoding: chunked` header value if no content-length is set, even if there's already a value. Werkzeug has the same behavior, but `hypercorn` does not.

After investigation, PEP3333 (https://peps.python.org/pep-3333/#id34) actually says that a WSGI application should not set the header itself; as it is the responsibility of the web server to manage this. It is true that it felt wrong from the application itself to dictate the server behavior. I believe GZIP is a bit of a different beast, as it relates more to the content itself of the response than the way the server will send it back. 

> (Note: applications and middleware **must not** apply any kind of Transfer-Encoding to their output, such as chunking or gzipping; as “hop-by-hop” operations, these encodings are the province of the actual web server/gateway. See [Other HTTP Features](https://peps.python.org/pep-3333/#other-http-features) below, for more details.)

So the more natural fix is to remove the `Transfer-Encoding: chunked` value from the header returned by the proxy, as the webserver will take care of that. We have specific tests around the automatic adding of this header when the request does not have content-length and have a generator as `response`. 

<!-- How does Rolo behave differently after this PR? -->
## Changes
- add tests for Proxy and ProxyHandler behavior around transfer-encoding, asserting that the proxy itself does not have `Transfer-Encoding` in its response headers to proxy forward, and that the `ProxyHandler` properly returns chunked response
- selectively filter the `Transfer-Encoding: chunked` value out of `Transfer-Encoding` so that we do not return it, but keep `gzip`

\cc @lukqw 

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
