### PR TITLE
fix header casing for Twisted WebSockets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "rolo"
 authors = [
     { name = "LocalStack Contributors", email = "info@localstack.cloud" }
 ]
-version = "0.7.4"
+version = "0.7.5"
 description = "A Python framework for building HTTP-based server applications"
 dependencies = [
     "requests>=2.20",

--- a/rolo/testing/pytest.py
+++ b/rolo/testing/pytest.py
@@ -17,7 +17,7 @@ from rolo.gateway import Gateway
 from rolo.gateway.asgi import AsgiGateway
 from rolo.gateway.wsgi import WsgiGateway
 from rolo.routing import handler_dispatcher
-from rolo.serving.twisted import TwistedGateway, HeaderPreservingHTTPChannel
+from rolo.serving.twisted import HeaderPreservingHTTPChannel, TwistedGateway
 from rolo.websocket.adapter import WebSocketListener
 
 if typing.TYPE_CHECKING:

--- a/rolo/testing/pytest.py
+++ b/rolo/testing/pytest.py
@@ -17,7 +17,7 @@ from rolo.gateway import Gateway
 from rolo.gateway.asgi import AsgiGateway
 from rolo.gateway.wsgi import WsgiGateway
 from rolo.routing import handler_dispatcher
-from rolo.serving.twisted import TwistedGateway
+from rolo.serving.twisted import TwistedGateway, HeaderPreservingHTTPChannel
 from rolo.websocket.adapter import WebSocketListener
 
 if typing.TYPE_CHECKING:
@@ -250,6 +250,7 @@ def serve_twisted_websocket_listener(twisted_reactor, serve_twisted_tcp_server):
                 websocketListener=websocket_listener,
             )
         )
+        site.protocol = HeaderPreservingHTTPChannel.protocol_factory
         return serve_twisted_tcp_server(site)
 
     return _create

--- a/rolo/testing/pytest.py
+++ b/rolo/testing/pytest.py
@@ -237,6 +237,12 @@ def serve_twisted_gateway(serve_twisted_tcp_server):
 
 @pytest.fixture
 def serve_twisted_websocket_listener(twisted_reactor, serve_twisted_tcp_server):
+    """
+    This fixture creates a Twisted Site, without the need to serve a fully-fledged rolo Gateway.
+    This is inspired by `rolo.serving.twisted.TwistedGateway`, but directly uses `WebsocketResourceDecorator` to
+    pass the `WebSocketListener` instead of `gateway.accept` to the `websocketListener` parameter.
+    It allows us to test the low-level behavior of WebSockets without being dependent on the Gateway implementation.
+    """
     from twisted.web.server import Site
 
     from rolo.serving.twisted import HeaderPreservingWSGIResource, WebsocketResourceDecorator

--- a/rolo/websocket/request.py
+++ b/rolo/websocket/request.py
@@ -117,8 +117,9 @@ class WebSocketRequest(_SansIORequest):
         """
         raw_headers = environ.get("rolo.headers")
         if raw_headers:
-            # restores raw headers from Twisted/ASGI scope, to have proper casing or dashes
-            # Similar to what we do in wsgi.py to restore Twisted casing handling
+            # restores raw headers from the server scope, to have proper casing or dashes. This can depend on server
+            # behavior, but we want a unified way to keep header casing/formatting.
+            # This is similar to what we do in wsgi.py
             headers = Headers(
                 MultiDict([(k.decode("latin-1"), v.decode("latin-1")) for (k, v) in raw_headers])
             )

--- a/tests/websocket/test_websockets.py
+++ b/tests/websocket/test_websockets.py
@@ -92,7 +92,8 @@ def test_websocket_headers(serve_websocket_listener):
 
     client = websocket.WebSocket()
     client.connect(
-        server.url.replace("http://", "ws://"), header=["Authorization: Basic let-me-in", "CasedHeader: hello"]
+        server.url.replace("http://", "ws://"),
+        header=["Authorization: Basic let-me-in", "CasedHeader: hello"],
     )
 
     assert client.handshake_response.status == 101
@@ -181,7 +182,9 @@ def test_router_integration(serve_websocket_listener):
 
     server = serve_websocket_listener(WebSocketRequest.listener(router.dispatch))
     client = websocket.WebSocket()
-    client.connect(server.url.replace("http://", "ws://") + "/foo/bar", header=["CasedHeader: hello"])
+    client.connect(
+        server.url.replace("http://", "ws://") + "/foo/bar", header=["CasedHeader: hello"]
+    )
     assert client.recv() == "foo"
     assert client.recv() == "id=bar"
     assert "CasedHeader" in json.loads(client.recv())


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
While implementing a service that uses WebSockets, I realized we were not keeping header casing with WebSockets served over Twisted, but we would in ASGI.

This was due to a workaround with the saved `rolo.headers` that is not executed in this code path while creating the `WebSocketRequest`. 

I've ported the fix over there, and it's exactly the same code that is living in `wsgi.py`. However, there isn't really a place for those kind of... utils? So for now it is duplicated. 

While testing the fix, I realized it was actually fixing the issue in my code served over LocalStack, but was still failing in the unit tests.
This is because the test was served over a simple `Site`, when you are supposed to serve it over a `WsgiGateway`, which contains some logic to preserve header casing. In order to not complicate the unit tests by requiring everything to be a rolo Gateway, I've applied the fix for the WebSockets `Site` fixture by adding the `site.protocol = HeaderPreservingHTTPChannel.protocol_factory` like we would in the `twisted.WsgiGateway`. 

<!-- How does Rolo behave differently after this PR? -->
## Changes
- update the tests to cover cased headers
- update the `serve_twisted_websocket_listener` to be closer to how Twisted should actually be used (with the Gateway)
- fix the logic by adding the restoration of header casing before creating the SansIO `Request`

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
