### PR TITLE
Remove accept encoding header

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,41 @@
+from pytest_httpserver import HTTPServer
+from werkzeug import Request as WerkzeugRequest
+from werkzeug.datastructures import Headers
+
+from rolo import Response
+from rolo.client import SimpleRequestsClient
+from rolo.request import Request
+
+
+def echo_request_metadata_handler(request: WerkzeugRequest) -> Response:
+    """
+    Simple request handler that returns the incoming request metadata (method, path, url, headers).
+
+    :param request: the incoming HTTP request
+    :return: an HTTP response
+    """
+    response = Response()
+    response.set_json(
+        {
+            "method": request.method,
+            "path": request.path,
+            "url": request.url,
+            "headers": dict(Headers(request.headers)),
+        }
+    )
+    return response
+
+
+class TestSimpleRequestClient:
+    def test_empty_accept_encoding_header(self, httpserver: HTTPServer):
+        httpserver.expect_request("/").respond_with_handler(echo_request_metadata_handler)
+
+        url = httpserver.url_for("/")
+
+        request = Request(path="/", method="GET")
+
+        with SimpleRequestsClient() as client:
+            response = client.request(request, url)
+
+        assert "Accept-Encoding" not in response.json["headers"]
+        assert "accept-encoding" not in response.json["headers"]

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -239,6 +239,7 @@ class TestProxy:
             assert response.json["headers"]["X-My-Custom-Header"] == "hello world"
             assert response.json["headers"]["X-Forwarded-For"] == "127.0.0.10"
             assert response.json["headers"]["Host"] == "127.0.0.1:80"
+            assert "Accept-Encoding" not in response.json["headers"]
 
     @pytest.mark.parametrize("chunked", [True, False])
     def test_proxy_for_transfer_encoding_chunked(


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Investigating issues with ApiGateway sending wrong `Accept-Encoding` headers to it's integration, with @bentsku, we found `urllib3.util.SKIP_HEADER` which let's us prevent `requests` from adding the specified header.

<!-- How does Rolo behave differently after this PR? -->
## Changes

- Adds `SKIP_HEADER` instead of `identity` when the `Accept-Encoding` header isn't set
- Adds tests

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
