### PR TITLE
Typing: Add overload to Router.add() for function-style endpoints

### DIFF
--- a/rolo/routing/router.py
+++ b/rolo/routing/router.py
@@ -167,6 +167,31 @@ class Router(t.Generic[E]):
         ...
 
     @overload
+    def add(
+        self,
+        path: str,
+        endpoint: t.Callable[[Request, ...], Response],
+        host: t.Optional[str] = None,
+        methods: t.Optional[t.Iterable[str]] = None,
+        **kwargs,
+    ) -> Rule:
+        """
+        Creates a new Rule from the given parameters and adds it to the URL Map.
+
+        TODO: many callers still expect ``add`` to return a single rule rather than a list, but it would be better to
+         homogenize the API and make every method return a list.
+
+        :param path: the path pattern to match. This path rule, in contrast to the default behavior of Werkzeug, will be
+                        matched against the raw / original (potentially URL-encoded) path.
+        :param endpoint: the function to invoke
+        :param host: an optional host matching pattern. if not pattern is given, the rule matches any host
+        :param methods: the allowed HTTP verbs for this rule
+        :param kwargs: any other argument that can be passed to ``werkzeug.routing.Rule``
+        :return: the rule that was created
+        """
+        ...
+
+    @overload
     def add(self, fn: _RouteEndpoint) -> list[Rule]:
         """
         Adds a RouteEndpoint (typically a function decorated with ``@route``) as a rule to the router.


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
One fairly common use case (in my experience) is to use a regular function as an endpoint, i.e.:
```python

ROUTER.add(
    path="/<path:path>",
    methods=["PUT"],
    endpoint=self.my_func,
)

def my_func(self, request: Request, path: str) -> Response:
    return Response(status=200, response=b"..")
```

Running MyPy on this currently throws an error:
```
error: No overload variant of "add" of "Router" matches argument types "str", "list[str]", "Callable[[Request, str, str, str, str], Response]"  [call-overload]
note: Possible overload variants:
note:     def add(self, path: str, endpoint: Handler, host: str | None = ..., methods: Iterable[str] | None = ..., **kwargs: Any) -> Rule
note:     def add(self, fn: _RouteEndpoint) -> list[Rule]
note:     def add(self, rule_factory: RuleFactory) -> list[Rule]
note:     def add(self, obj: Any) -> list[Rule]
note:     def add(self, routes: list[_RouteEndpoint | RuleFactory | Any]) -> list[Rule]
```

Adding this overload solves the problem, and removes the need to add `type: ignore`'s all over the place


