### PR TITLE
add tag-based release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Build release
         run: make dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
       - 'docs/**'
     branches:
       - main
+    tags:
+      - 'v*.*'
   pull_request:
     branches:
       - main
@@ -22,11 +24,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -45,3 +47,32 @@ jobs:
       - name: Report coverage
         run: |
           make coveralls
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rolo
+    permissions:
+      id-token: write
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build release
+        run: make dist
+
+      - name: List artifacts
+        run: ls -lah dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ venv.bak/
 
 # sqlite database files created by examples
 *.db
+
+# Hatch VCS hook generates this file during build
+rolo/version.py

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ venv: $(VENV_ACTIVATE)
 
 $(VENV_ACTIVATE): pyproject.toml
 	test -d .venv || $(VENV_BIN) .venv
-	$(VENV_RUN); pip install --upgrade pip setuptools wheel
+	$(VENV_RUN); pip install --upgrade pip
 	$(VENV_RUN); pip install -e .[dev]
 	touch $(VENV_DIR)/bin/activate
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,12 @@
 [build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "rolo"
 authors = [
     { name = "LocalStack Contributors", email = "info@localstack.cloud" }
 ]
-version = "0.8.0"
 description = "A Python framework for building HTTP-based server applications"
 dependencies = [
     "requests>=2.20",
@@ -26,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries"
 ]
-dynamic = ["readme"]
+dynamic = ["readme", "version"]
 
 
 [project.optional-dependencies]
@@ -48,18 +47,11 @@ docs = [
     "myst_parser",
 ]
 
-[tool.setuptools]
-include-package-data = false
+[tool.hatch.version]
+source = "vcs"
 
-[tool.setuptools.dynamic]
-readme = {file = ["README.md"], content-type = "text/markdown"}
-
-[tool.setuptools.packages.find]
-include = ["rolo*"]
-exclude = ["tests*"]
-
-[tool.setuptools.package-data]
-"*" = ["*.md"]
+[tool.hatch.build.hooks.vcs]
+version-file = "rolo/version.py"
 
 [tool.black]
 line_length = 100

--- a/rolo/__init__.py
+++ b/rolo/__init__.py
@@ -2,6 +2,7 @@ from .request import Request
 from .response import Response
 from .routing.resource import Resource, resource
 from .routing.router import Router, route
+from .version import __version__
 
 __all__ = [
     "route",
@@ -10,4 +11,5 @@ __all__ = [
     "Router",
     "Response",
     "Request",
+    "__version__",
 ]


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

We've been migrating to hatch-vcs and tag-based releasing for our OSS libraries.
* https://github.com/localstack/plux/pull/39
* https://github.com/localstack/verdin/pull/11

Following our user guide for tag-based pypi releases, I made all the necessary changes. I already configured GitHub and PyPI accordingly.

<!-- How does Rolo behave differently after this PR? -->
## Changes

* rolo now uses hatch-vcs to compute the version number
* releases can be made by tagging a commit with `vM.m.p` and pushing it

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
